### PR TITLE
fix(list_symbols): Use IXSCAN queries for the versions collection when querying symbols

### DIFF
--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -121,7 +121,11 @@ def test_indexes(arctic):
                                                           u'key': [(u'symbol', 1), (u'version', -1)],
                                                           u'ns': u'arctic.library.versions',
                                                           u'unique': True,
-                                                          u'v': index_version}}
+                                                          u'v': index_version},
+                                 u'symbol_1_version_-1_metadata.deleted_1': {u'background': True,
+                                                                             u'key': [(u'symbol', 1), (u'version', -1), (u'metadata.deleted', 1)],
+                                                                             u'ns': u'arctic.library.versions',
+                                                                             u'v': index_version}}
     version_nums = c.arctic.library.version_nums.index_information()
     assert version_nums == {u'_id_': {u'key': [(u'_id', 1)],
                                                u'ns': u'arctic.library.version_nums',

--- a/tests/integration/test_arctic_multithreading.py
+++ b/tests/integration/test_arctic_multithreading.py
@@ -13,6 +13,7 @@ from arctic.store.version_store import VersionStore
 MY_ARCTIC = None  # module-level Arctic singleton
 AUTH_COUNT = 0
 
+
 def f(library_name, total_writes, do_reset):
     my_pid = os.getpid()
     data = [str(my_pid)] * 100

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,0 +1,8 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def enable_profiling_for_library(library):
+    library._arctic_lib._db.set_profiling_level(2)
+    yield library._arctic_lib._db['system.profile']
+    library._arctic_lib._db.set_profiling_level(0, slow_ms=100)


### PR DESCRIPTION
This is mainly a reversion on https://github.com/man-group/arctic/pull/520, but we add another index to avoid a FETCH stage which gives a massive speedup.