### PR TITLE
Fix missing column handling in numpy serializer.

### DIFF
--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -150,7 +150,7 @@ class FrameConverter(object):
             # if there is missing data in a chunk, we can default to NaN
             # and pandas will autofill the missing values to the correct length
             if col not in doc[METADATA][LENGTHS]:
-                d = [np.nan]
+                d = np.array(np.nan)
             else:
                 d = decompress(doc[DATA][doc[METADATA][LENGTHS][col][0]: doc[METADATA][LENGTHS][col][1] + 1])
                 # d is ready-only but that's not an issue since DataFrame will copy the data anyway.

--- a/tests/unit/serialization/test_numpy_arrays.py
+++ b/tests/unit/serialization/test_numpy_arrays.py
@@ -83,6 +83,14 @@ def test_string_cols_with_nans():
     assert(df.equals(f.objify(f.docify(df))))
 
 
+def test_objify_with_missing_columns():
+    f = FrameConverter()
+    df = pd.DataFrame(data={'one': ['a', 'b', 'c', np.NaN]})
+    res = f.objify(f.docify(df), columns=['one', 'two'])
+    assert res['one'].equals(df['one'])
+    assert all(res['two'].isnull())
+
+
 def test_multi_column_fail():
     df = pd.DataFrame(data={'A': [1, 2, 3], 'B': [2, 3, 4], 'C': [3, 4, 5]})
     df = df.set_index(['A'])


### PR DESCRIPTION
Bug in numpy serializer objify function causes issues in dataframe construction when a given column passed into the columns does not exist. 
 
```
import numpy as np
import pandas as pd
from arctic.serialization.numpy_arrays import FrameConverter, FrametoArraySerializer

f = FrameConverter()
df = pd.DataFrame(data={'one': ['a', 'b', 'c', np.NaN]})
res = f.objify(f.docify(df), columns=['one', 'two'])
```
```
Traceback (most recent call last):
  File "/home/abai/pyenvs/arctic/lib/python3.6/site-packages/ipython-7.7.0-py3.6.egg/IPython/core/interactiveshell.py", line 3326, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-4-9e264fac0a78>", line 1, in <module>
    res = f.objify(f.docify(df), columns=['one', 'two'])
  File "/home/abai/code/arctic/arctic/serialization/numpy_arrays.py", line 166, in objify
    return pd.DataFrame(data, columns=cols, copy=True)[cols]
  File "/home/abai/pyenvs/arctic/lib/python3.6/site-packages/pandas-0.22.0+ahl1-py3.6-linux-x86_64.egg/pandas/core/frame.py", line 330, in __init__
    mgr = self._init_dict(data, index, columns, dtype=dtype)
  File "/home/abai/pyenvs/arctic/lib/python3.6/site-packages/pandas-0.22.0+ahl1-py3.6-linux-x86_64.egg/pandas/core/frame.py", line 419, in _init_dict
    extract_index(list(data.values()))
  File "/home/abai/pyenvs/arctic/lib/python3.6/site-packages/pandas-0.22.0+ahl1-py3.6-linux-x86_64.egg/pandas/core/frame.py", line 6218, in extract_index
    raise ValueError('arrays must all be same length')
ValueError: arrays must all be same length

```

It seems like the intended behavior is to output a column of NaNs in that case so removing the NaN from the list will allow the NaN to broadcast in the dataframe construction. 

