### PR TITLE
Fix for issue #815

### DIFF
--- a/arctic/_util.py
+++ b/arctic/_util.py
@@ -3,7 +3,10 @@ import logging
 import numpy as np
 import pymongo
 from pandas import DataFrame
-from pandas.util.testing import assert_frame_equal
+try:
+	from pandas.testing import assert_frame_equal
+except ImportError:
+	from pandas.util.testing import assert_frame_equal
 
 from ._config import FW_POINTERS_CONFIG_KEY, FwPointersCfg
 

--- a/arctic/_util.py
+++ b/arctic/_util.py
@@ -4,9 +4,9 @@ import numpy as np
 import pymongo
 from pandas import DataFrame
 try:
-	from pandas.testing import assert_frame_equal
+    from pandas.testing import assert_frame_equal
 except ImportError:
-	from pandas.util.testing import assert_frame_equal
+    from pandas.util.testing import assert_frame_equal
 
 from ._config import FW_POINTERS_CONFIG_KEY, FwPointersCfg
 

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -3,7 +3,11 @@ import logging
 
 import numpy as np
 from bson.binary import Binary
-from pandas import DataFrame, Series, Panel
+from pandas import DataFrame, Series
+try:
+	from pandas import Panel
+except ImportError:
+	pass
 
 from arctic._util import NP_OBJECT_DTYPE
 from arctic.serialization.numpy_records import SeriesSerializer, DataFrameSerializer

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -5,9 +5,9 @@ import numpy as np
 from bson.binary import Binary
 from pandas import DataFrame, Series
 try:
-	from pandas import Panel
+    from pandas import Panel
 except ImportError:
-	pass
+    pass
 
 from arctic._util import NP_OBJECT_DTYPE
 from arctic.serialization.numpy_records import SeriesSerializer, DataFrameSerializer

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -8,7 +8,11 @@ import pandas as pd
 import pytest
 from dateutil.rrule import rrule, DAILY
 from mock import Mock, patch
-from pandas import DataFrame, Series, DatetimeIndex, MultiIndex, read_csv, Panel, date_range, concat
+from pandas import DataFrame, Series, DatetimeIndex, MultiIndex, read_csv, date_range, concat
+try:
+    from pandas import Panel
+except ImportError:
+    pass
 from pandas.tseries.offsets import DateOffset
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 from six import StringIO

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -648,6 +648,7 @@ def panel(i1, i2, i3):
                  list(rrule(DAILY, count=i3, dtstart=dt(1970, 1, 1), interval=1)))
 
 
+@pytest.mark.skipif(pd.__version__ >= '0.25.0', reason="Panel has been removed")
 @pytest.mark.xfail(pd.__version__ >= '0.18.0', reason="see issue #115")
 @pytest.mark.parametrize("df_size", list(itertools.combinations_with_replacement([1, 2, 4], r=3)))
 def test_panel_save_read(library, df_size):
@@ -663,6 +664,7 @@ def test_panel_save_read(library, df_size):
                 str(pn.axes[i].names) + "!=" + str(pn.axes[i].names)
 
 
+@pytest.mark.skipif(pd.__version__ >= '0.25.0', reason="Panel has been removed")
 @pytest.mark.xfail(pd.__version__ >= '0.20.0', reason='Panel is deprecated')
 def test_panel_save_read_with_nans(library):
     '''Ensure that nan rows are not dropped when calling to_frame.'''

--- a/tests/unit/store/test_pandas_ndarray_store.py
+++ b/tests/unit/store/test_pandas_ndarray_store.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from mock import Mock, sentinel, patch
 from pytest import raises
 

--- a/tests/unit/store/test_pandas_ndarray_store.py
+++ b/tests/unit/store/test_pandas_ndarray_store.py
@@ -7,6 +7,7 @@ from arctic.store._pandas_ndarray_store import PandasDataFrameStore, PandasPanel
 from tests.util import read_str_as_pandas
 
 
+@pytest.mark.skipif(pd.__version__ >= '0.25.0', reason="Panel has been removed")
 def test_panel_converted_to_dataframe_and_stacked_to_write():
     store = PandasPanelStore()
     panel = Mock(shape=(1, 2, 3), axes=[Mock(names=['n%d' % i]) for i in range(3)])
@@ -20,6 +21,7 @@ def test_panel_converted_to_dataframe_and_stacked_to_write():
                                   DF.return_value, sentinel.prev)
 
 
+@pytest.mark.skipif(pd.__version__ >= '0.25.0', reason="Panel has been removed")
 def test_panel_append_not_supported():
     store = PandasPanelStore()
     panel = Mock(shape=(1, 2, 3), axes=[Mock(names=['n%d' % i]) for i in range(3)], dtypes=['a'])
@@ -27,6 +29,7 @@ def test_panel_append_not_supported():
         store.append(sentinel.mlib, sentinel.version, sentinel.symbol, panel, sentinel.prev)
 
 
+@pytest.mark.skipif(pd.__version__ >= '0.25.0', reason="Panel has been removed")
 def test_panel_converted_from_dataframe_for_reading():
     store = PandasPanelStore()
     with patch.object(PandasDataFrameStore, 'read') as mock_read:
@@ -35,6 +38,7 @@ def test_panel_converted_from_dataframe_for_reading():
     assert res == mock_read.return_value.to_panel.return_value
 
 
+@pytest.mark.skipif(pd.__version__ >= '0.25.0', reason="Panel has been removed")
 def test_raises_upon_empty_panel_write():
     store = PandasPanelStore()
     panel = Mock(shape=(1, 0, 3))

--- a/tests/unit/store/test_pandas_ndarray_store.py
+++ b/tests/unit/store/test_pandas_ndarray_store.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from mock import Mock, sentinel, patch
 from pytest import raises
 


### PR DESCRIPTION
I produced a fix for the import errors/deprecations in issue #815.
With a recent version of Pandas, importing Panel results in an error, not just a future warning.
Please have a look at it.