### PR TITLE
Handle uninitialized cache object

### DIFF
--- a/arctic/_cache.py
+++ b/arctic/_cache.py
@@ -84,8 +84,9 @@ class Cache:
             if cached_data and self._is_not_expired(cached_data, newer_than_secs):
                 return cached_data['data']
         except OperationFailure as op:
-            logging.warning("Could not read from cache due to: %s. Ask your admin to give read permissions on %s:%s",
-                            op, CACHE_DB, CACHE_COLL)
+            # Fallback to uncached version without spamming.
+            logging.debug("Could not read from cache due to: %s. Ask your admin to give read permissions on %s:%s",
+                          op, CACHE_DB, CACHE_COLL)
 
         return None
 

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -203,7 +203,9 @@ class Arctic(object):
         -------
         list of Arctic library names
         """
-        return self._list_libraries_cached(newer_than_secs) if self.is_caching_enabled() else self._list_libraries()
+        if self._cache and self.is_caching_enabled():
+            return self._list_libraries_cached(newer_than_secs)
+        return self._list_libraries()
 
     @mongo_retry
     def _list_libraries(self):

--- a/arctic/store/_pickle_store.py
+++ b/arctic/store/_pickle_store.py
@@ -95,7 +95,11 @@ class PickleStore(object):
         collection = arctic_lib.get_top_level_collection()
         # Try to pickle it. This is best effort
         version['blob'] = _MAGIC_CHUNKEDV2
-        pickled = cPickle.dumps(item, protocol=cPickle.HIGHEST_PROTOCOL)
+        # Python 3.8 onwards uses protocol 5 which cannot be unpickled in Python versions below that, so limiting
+        # it to use a maximum of protocol 4 in Python which is understood by 3.4 onwards and is still fairly efficient.
+        # The min() allows lower versions to be used in py2 (which supports a max of 2)
+        pickle_protocol = min(cPickle.HIGHEST_PROTOCOL, 4)
+        pickled = cPickle.dumps(item, protocol=pickle_protocol)
 
         data = compress_array([pickled[i * _CHUNK_SIZE: (i + 1) * _CHUNK_SIZE] for i in xrange(int(len(pickled) / _CHUNK_SIZE + 1))])
 


### PR DESCRIPTION
If _cache is not initialized - I have seen this in some contexts with forking involved - just return the uncached list_libraries.