### PR TITLE
Speed up chunkstore reads with index

### DIFF
--- a/arctic/chunkstore/chunkstore.py
+++ b/arctic/chunkstore/chunkstore.py
@@ -63,8 +63,8 @@ class ChunkStore(object):
                                       background=True)
         self._collection.create_index([(SYMBOL, pymongo.ASCENDING),
                                        (START, pymongo.ASCENDING),
-                                       (END, pymongo.ASCENDING),
-                                       (SEGMENT, pymongo.ASCENDING)],
+                                       (SEGMENT, pymongo.ASCENDING),
+                                       (END, pymongo.ASCENDING)],
                                       unique=True, background=True)
         self._collection.create_index([(SYMBOL, pymongo.ASCENDING),
                                        (START, pymongo.ASCENDING),


### PR DESCRIPTION
Correcting the index to correctly be used in read(..)

https://www.mongodb.com/blog/post/performance-best-practices-indexing

See ESR rule