### PR TITLE
Remove restriction on pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
                       "enum-compat",
                       "futures; python_version == '2.7'",
                       "mockextras",
-                      "pandas<=1.0.3",
+                      "pandas",
                       "pymongo>=3.6.0",
                       "python-dateutil",
                       "pytz",


### PR DESCRIPTION
Removing the restriction on pandas version since the Panel fixes should make it no longer necessary. Various people have reported arctic working latest version of Pandas. Without this fix, arctic forces the use of older versions of Pandas which can lead to conflicts with other libraries.