### PR TITLE
Speedup FrametoArray serializer for ChunkStore

### DIFF
--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -7,7 +7,7 @@ from bson import Binary, SON
 
 from .._compression import compress, decompress, compress_array
 from ._serializer import Serializer
-
+from collections import defaultdict
 try:
     from pandas.api.types import infer_dtype
 except ImportError:
@@ -139,31 +139,35 @@ class FrameConverter(object):
 
         return doc
 
-    def objify(self, doc, columns=None):
+    def objify(self, doc, columns=None, as_df=True):
         """
         Decode a Pymongo SON object into an Pandas DataFrame
         """
         cols = columns or doc[METADATA][COLUMNS]
         data = {}
+        valid_columns = doc[METADATA][LENGTHS]
+        missing_columns = set(cols).difference(valid_columns)
+        for col in valid_columns:
+            d = decompress(doc[DATA][doc[METADATA][LENGTHS][col][0]: doc[METADATA][LENGTHS][col][1] + 1])
+            # d is ready-only but that's not an issue since DataFrame will copy the data anyway.
+            d = np.frombuffer(d, doc[METADATA][DTYPE][col])
 
-        for col in cols:
-            # if there is missing data in a chunk, we can default to NaN
-            # and pandas will autofill the missing values to the correct length
-            if col not in doc[METADATA][LENGTHS]:
-                d = np.array(np.nan)
-            else:
-                d = decompress(doc[DATA][doc[METADATA][LENGTHS][col][0]: doc[METADATA][LENGTHS][col][1] + 1])
-                # d is ready-only but that's not an issue since DataFrame will copy the data anyway.
-                d = np.frombuffer(d, doc[METADATA][DTYPE][col])
-
-                if MASK in doc[METADATA] and col in doc[METADATA][MASK]:
-                    mask_data = decompress(doc[METADATA][MASK][col])
-                    mask = np.frombuffer(mask_data, 'bool')
-                    d = ma.masked_array(d, mask)
+            if MASK in doc[METADATA] and col in doc[METADATA][MASK]:
+                mask_data = decompress(doc[METADATA][MASK][col])
+                mask = np.frombuffer(mask_data, 'bool')
+                d = ma.masked_array(d, mask)
             data[col] = d
 
-        # Copy into
-        return pd.DataFrame(data, columns=cols, copy=True)[cols]
+        for col in missing_columns:
+            # if there is missing data in a chunk, we can default to NaN and
+            empty = np.empty(len(d))
+            empty[:] = np.nan
+            data[col] = empty
+
+        if as_df:
+            return pd.DataFrame(data)
+
+        return data
 
 
 class FrametoArraySerializer(Serializer):
@@ -222,12 +226,24 @@ class FrametoArraySerializer(Serializer):
                 raise Exception("Duplicate columns specified, cannot de-serialize")
 
         if not isinstance(data, list):
-            df = self.converter.objify(data, columns)
-        else:
-            df = pd.concat([self.converter.objify(d, columns) for d in data], ignore_index=not index)
+            data = [data]
 
-        if index:
-            df = df.set_index(meta[INDEX])
+        df = defaultdict(list)
+
+        for d in data:
+            for k, v in self.converter.objify(d, columns, as_df=False).items():
+                df[k].append(v)
+
+        idx_cols = meta[INDEX] if index else []
+        if len(idx_cols) > 1:
+            idx = pd.MultiIndex.from_arrays([np.concatenate(df[k]) for k in idx_cols], names=idx_cols)
+        elif len(idx_cols) == 1:
+            idx = pd.Index(np.concatenate(df[idx_cols[0]]), name=idx_cols[0])
+        else:
+            idx = None
+
+        df = pd.DataFrame({k: np.concatenate(v) for k, v in df.items() if k not in idx_cols}, index=idx)
+
         if meta[TYPE] == 'series':
             return df[df.columns[0]]
         return df


### PR DESCRIPTION
**Summary**
Speedup FrametoArray serializer for ChunkStore by removing intermediate DataFrame construction.
The majority of the time spent for serialization is spent on the following:
1. Constructing intermediate DataFrames
2. Setting the index:
![image](https://user-images.githubusercontent.com/37855280/125506081-2a0e747c-e844-47e7-80f8-3ac4d8466862.png)
![image](https://user-images.githubusercontent.com/37855280/125505969-aebd4fd9-101c-4cbc-8d20-579465186d2a.png)

By removing the intermediate DataFrame construction (so we only use numpy arrays and construct the DataFrame at the very end) and constructing the index separately, we can speed the serialization up significantly. 

**Performance comparisons**
---------------------------------
**No Index - Series**
```
    df = pd.Series(range(100))
    a = FrametoArraySerializer().serialize(df)
```
1. Single Chunk:
![image](https://user-images.githubusercontent.com/37855280/125511882-842f3974-11df-4125-9872-e7b4a357cd24.png)
2. Multiple Chunks (data in list):
![image](https://user-images.githubusercontent.com/37855280/125512030-6d4d6f3d-f535-4e22-948f-c3c06af3ff7e.png)

**With Index - Series**
```
    df = pd.Series(range(100), index=pd.Index(range(100), name='A'))
    a = FrametoArraySerializer().serialize(df)
```
1. Single Chunk:
![image](https://user-images.githubusercontent.com/37855280/125513303-95bcea8b-6ee4-4537-97ac-ade0cdcaf565.png)
2. Multiple Chunks (data in list):
![image](https://user-images.githubusercontent.com/37855280/125513361-05f4ba5b-2027-40c4-8531-60388d2ff46d.png)


**No Index - Multiple columns**
```
    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
                      columns=list('ABCD'))
    a = FrametoArraySerializer().serialize(df)
```

1. Single chunk (shape: (100, 4))
![image](https://user-images.githubusercontent.com/37855280/125510173-2d86cf39-0210-4764-9177-6ef3b18a9c27.png)


2. Multiple chunks (data in list):
![image](https://user-images.githubusercontent.com/37855280/125510345-82853dbb-597c-48c8-b4d1-969245fd4d54.png)


**With Index - Multiple columns**
```
    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
                      columns=list('ABCD'))
    df = df.set_index(['A'])
    a = FrametoArraySerializer().serialize(df)
```

1. Single chunk (shape: (100, 4))
![image](https://user-images.githubusercontent.com/37855280/125510671-ff63ad3c-1812-45a1-a079-efa084949b2d.png)


2. Multiple chunks (data in list):
![image](https://user-images.githubusercontent.com/37855280/125510787-97c34184-8659-4baf-9b22-952905a5eb58.png)





