### PR TITLE
Pymongo 3.11.0 avoid slow mongo_count

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ defaults: &defaults
         name: Version checks
         command: |
             grep -q $VERSION CHANGES.md || (echo "ERROR: Version number not found in CHANGES.md: $VERSION"; exit 1)
+
     - run:
         name: Output useful stuff
         command: |
@@ -33,6 +34,7 @@ defaults: &defaults
         command: |
             # run "cat /etc/os-release" to view information about the OS
             # good article on how to install mongo, https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/
+
             cat /etc/os-release
             set -x
             wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,27 +13,22 @@ defaults: &defaults
         - v1-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
-    #- restore_cache:
-    #    name: Restore Yarn Package Cache
-    #    keys:
-    #      - yarn-packages-{{ checksum "notebooker/web/static/yarn.lock" }}
     - run:
         name: Version checks
         command: |
-            #grep -q $VERSION notebooker/version.py || (echo "ERROR: Version number not found in notebooker/_version.py: $VERSION"; exit 1)
             grep -q $VERSION CHANGES.md || (echo "ERROR: Version number not found in CHANGES.md: $VERSION"; exit 1)
-            #grep -q $VERSION docs/conf.py || (echo "ERROR: Version number not found in docs/source/conf.py: $VERSION"; exit 1)
-            #grep -q $VERSION notebooker/web/static/package.json || (echo "ERROR: Version number not found in package.json: $VERSION"; exit 1)
+
     - run:
         name: Output useful stuff
         command: |
           echo $VERSION > "$CIRCLE_ARTIFACTS/version.txt"
           # Find the lines of the changelog between releases, escape double quotes, delete empty lines
-          sed -n '{ /------/= }' CHANGES.md \
-              | head -n 2 \
-              | xargs -n 2 bash -c 'sed -n "s/\"/\\\\\"/g;`expr $0 + 1`,`expr $1 - 2`p" CHANGES.md' \
-              | sed '/^$/d' \
-              > "$CIRCLE_ARTIFACTS/changes.md"
+          # Simply gets the current changes from top of changelog.
+          #sed -n '{ /------/= }' CHANGES.md \
+              #| head -n 2 \
+              #| xargs -n 2 bash -c 'sed -n "s/\"/\\\\\"/g;`expr $0 + 1`,`expr $1 - 2`p" CHANGES.md' \
+              #| sed '/^$/d' \
+              #> "$CIRCLE_ARTIFACTS/changes.md"
     - run:
         name: Install MongoDB
         command: |
@@ -55,8 +50,10 @@ defaults: &defaults
        command: |
          virtualenv ci
          . ci/bin/activate
-         pip install pip python-dateutil pytz tzlocal pymongo numpy pandas decorator enum34 lz4 mock mockextras pytest pytest-cov pytest-server-fixtures pytest-timeout pytest-xdist setuptools-git pytest black .[test]
          python setup.py develop
+         pip install pytest-server-fixtures[mongodb]
+         pip freeze
+         python --version
     # Save dependency cache
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}
@@ -86,15 +83,7 @@ defaults: &defaults
          . ci/bin/activate
          ls -la /bin | grep mongo
          which mongod
-         #pip install -e .[prometheus,test]
-         #python -m ipykernel install --user --name=notebooker_kernel
-         #pip install -r ./notebooker/notebook_templates_example/notebook_requirements.txt
-         mkdir test-results
-         #arctic tests added
-         python setup.py test --pytest-args=-v
-         cp junit.xml test-results
-         #py.test -svvvvv --junitxml=test-results/junit.xml
-         #bash <(curl -s https://codecov.io/bash) -c -F python
+         py.test -svvvvv --junitxml=test-results/junit.xml
     - store_test_results:
         path: test-results
     # Save artifacts
@@ -110,6 +99,19 @@ defaults: &defaults
           - ./*/dist/*
 version: 2
 jobs:
+  build_2_7:
+    environment:
+      PYTHON_VERSION: "2_7"
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/2_7
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/2_7
+      VERSION: 1.80.0
+      #PANDOC_RELEASES_URL: https://github.com/jgm/pandoc/releases
+      #YARN_STATIC_DIR: notebooker/web/static/
+      IMAGE_NAME: mangroup/arctic
+    working_directory: ~/arctic_2_7
+    docker:
+    - image: cimg/python:2.7-node
+    <<: *defaults
   build_3_6:
     environment:
       PYTHON_VERSION: "3_6"
@@ -125,6 +127,7 @@ jobs:
     <<: *defaults
   build_3_7:
     environment:
+      PYTHON_VERSION: "3_7"
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/3_7
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/3_7
       VERSION: 1.80.0
@@ -146,26 +149,29 @@ jobs:
          command: |
            VERSION=$(cat /tmp/circleci-artifacts/3_6/version.txt)
            CHANGES=$(cat /tmp/circleci-artifacts/3_6/changes.md)
-  #         ghr -t ${GITHUB_TOKEN} \
-  #             -u ${CIRCLE_PROJECT_USERNAME} \
-  #             -r ${CIRCLE_PROJECT_REPONAME} \
-  #             -c ${CIRCLE_SHA1} \
-  #             -n ${VERSION} \
-  #             -b "${CHANGES}" \
-  #             -soft \
-  #             ${VERSION} /tmp/circleci-artifacts/3_6/dist
+           ghr -t ${GITHUB_TOKEN} \
+               -u ${CIRCLE_PROJECT_USERNAME} \
+               -r ${CIRCLE_PROJECT_REPONAME} \
+               -c ${CIRCLE_SHA1} \
+               -n ${VERSION} \
+               -b "${CHANGES}" \
+               -soft \
+               ${VERSION} /tmp/circleci-artifacts/3_6/dist
 workflows:
   version: 2
   build_all:
     jobs:
+      # just build 3.6 its all we need right now
+      #- build_2_7
       - build_3_6
       - build_3_7
-      - publish-github-release:
-          requires:
-            - build_3_6
-            - build_3_7
-          filters:
-            branches:
-              only:
-                - master
 
+      # do not publish
+      #- publish-github-release:
+      #    requires:
+      #      - build_3_6
+      #      - build_3_7
+      #    filters:
+      #      branches:
+      #        only:
+      #          - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ defaults: &defaults
         name: Version checks
         command: |
             grep -q $VERSION CHANGES.md || (echo "ERROR: Version number not found in CHANGES.md: $VERSION"; exit 1)
-
     - run:
         name: Output useful stuff
         command: |
@@ -34,7 +33,6 @@ defaults: &defaults
         command: |
             # run "cat /etc/os-release" to view information about the OS
             # good article on how to install mongo, https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/
-
             cat /etc/os-release
             set -x
             wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
@@ -104,7 +102,7 @@ jobs:
       PYTHON_VERSION: "2_7"
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/2_7
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/2_7
-      VERSION: 1.80.0
+      VERSION: 1.80.1
       #PANDOC_RELEASES_URL: https://github.com/jgm/pandoc/releases
       #YARN_STATIC_DIR: notebooker/web/static/
       IMAGE_NAME: mangroup/arctic
@@ -117,7 +115,7 @@ jobs:
       PYTHON_VERSION: "3_6"
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/3_6
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/3_6
-      VERSION: 1.80.0
+      VERSION: 1.80.1
       #PANDOC_RELEASES_URL: https://github.com/jgm/pandoc/releases
       #YARN_STATIC_DIR: notebooker/web/static/
       IMAGE_NAME: mangroup/arctic
@@ -130,7 +128,7 @@ jobs:
       PYTHON_VERSION: "3_7"
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/3_7
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/3_7
-      VERSION: 1.80.0
+      VERSION: 1.80.1
       #PANDOC_RELEASES_URL: https://github.com/jgm/pandoc/releases
       #YARN_STATIC_DIR: notebooker/web/static/
       IMAGE_NAME: mangroup/arctic

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### 1.80.1
-  * Bugfix: #855 use IXSCAN for list\_symbols which speeds up snapshotting (actually #856)
+  * Bugfix: #855 use IXSCAN for list\_symbols which speeds up snapshotting (was not released in 1.79.4)
 
 ### 1.80.0 (2021-10-28)
   * Feature: #919 Add CircleCI badge to README.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### 1.80.1
   * Bugfix: #855 use IXSCAN for list\_symbols which speeds up snapshotting (was not released in 1.79.4)
+  * Bugfix: #926 avoid pathologically slow count_documents() call with pymongo > 3.6.0
 
 ### 1.80.0 (2021-10-28)
   * Feature: #919 Add CircleCI badge to README.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### 1.80.1
-  * Bugfix: #855 use IXSCAN for list\_symbols which speeds up snapshotting (was not released in 1.79.4)
+  * Bugfix: #855 use IXSCAN for list\_symbols which speeds up snapshotting (actually #856)
   * Bugfix: #926 avoid pathologically slow count_documents() call with pymongo > 3.6.0
 
 ### 1.80.0 (2021-10-28)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ It wouldn't be possible without the work of the AHL Data Engineering Team includ
  * [Bryant Moscon](https://github.com/bmoscon)
  * [Dimosthenis Pediaditakis](https://github.com/dimosped)
  * [Shashank Khare](https://github.com/shashank88)
+ * [Duncan Kerr](https://github.com/dunckerr)
  * ... and many others ...
 
 Contributions welcome!

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/arctic/badge/?version=latest)](https://arctic.readthedocs.io/en/latest/?badge=latest)
 [![CircleCI](https://circleci.com/gh/man-group/arctic/tree/master.svg?style=shield)](https://app.circleci.com/pipelines/github/man-group/arctic?branch=master)
+[![PyPI](https://img.shields.io/pypi/v/arctic)](https://pypi.org/project/arctic/)
 [![Travis CI](https://travis-ci.com/man-group/arctic.svg?branch=master)](https://travis-ci.org/man-group/arctic)
 [![Join the chat at https://gitter.im/manahl/arctic](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/manahl/arctic?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Arctic storage implementations are **pluggable**.  VersionStore is the default.
 
 Arctic currently works with:
 
- * Python 2.7, 3.4, 3.5, 3.6
- * pymongo >= 3.6
- * Pandas
+ * Python 3.5, 3.6
+ * pymongo 3.60 thru 3.11.0
+ * Pandas 0.22.0 thru 1.0.3
  * MongoDB >= 2.4.x
 
 

--- a/arctic/_util.py
+++ b/arctic/_util.py
@@ -24,6 +24,7 @@ def get_fwptr_config(version):
 
 def _detect_new_count_api():
     try:
+        print(f'detected mongo version {pymongo.version}')
         mongo_v = [int(v) for v in pymongo.version.split('.')]
         return mongo_v[0] >= 3 and mongo_v[1] >= 7
     except:
@@ -91,12 +92,16 @@ def mongo_count(collection, filter=None, **kwargs):
     _use_new_count_api = _detect_new_count_api() if _use_new_count_api is None else _use_new_count_api
 
     if _use_new_count_api:
+        print('new drivers detected')
         if filter == {}:
+            print('new drivers null filter')
             # fast. uses collection metadata
             return collection.estimated_document_count(**kwargs)
         else:
+            print('new drivers plus filter')
             # transactions supported, but slow for non-indexed filters
             return collection.count_documents(filter=filter, **kwargs)
     else:
+        print('old drivers detected')
         # pymongo <= 3.6 # faster than count_documents but non-transactional and deprecated
         return collection.count(filter=filter, **kwargs)

--- a/arctic/_util.py
+++ b/arctic/_util.py
@@ -24,7 +24,6 @@ def get_fwptr_config(version):
 
 def _detect_new_count_api():
     try:
-        print(f'detected mongo version {pymongo.version}')
         mongo_v = [int(v) for v in pymongo.version.split('.')]
         return mongo_v[0] >= 3 and mongo_v[1] >= 7
     except:
@@ -92,16 +91,12 @@ def mongo_count(collection, filter=None, **kwargs):
     _use_new_count_api = _detect_new_count_api() if _use_new_count_api is None else _use_new_count_api
 
     if _use_new_count_api:
-        print('new drivers detected')
         if filter == {}:
-            print('new drivers null filter')
             # fast. uses collection metadata
             return collection.estimated_document_count(**kwargs)
         else:
-            print('new drivers plus filter')
             # transactions supported, but slow for non-indexed filters
             return collection.count_documents(filter=filter, **kwargs)
     else:
-        print('old drivers detected')
         # pymongo <= 3.6 # faster than count_documents but non-transactional and deprecated
         return collection.count(filter=filter, **kwargs)

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -2,7 +2,10 @@ import logging
 import os
 import re
 import threading
+import warnings
 
+# just suppress for pymongo
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 import pymongo
 from pymongo.errors import OperationFailure, AutoReconnect
 from six import string_types

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
                       "mockextras",
                       "pandas<=1.0.3",
                       "numpy<=1.18.4",
-                      "pymongo>=3.6.0, <= 3.11.0"
+                      "pymongo>=3.6.0, <= 3.11.0",
                       #"pytest-server-fixtures", # must be manual
                       "pytest-cov",
                       "pytest",

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
                    ],
     install_requires=["decorator",
                       "enum-compat",
-                      #"enum34",
                       "mock",
                       "mockextras",
                       "pandas<=1.0.3",
@@ -84,12 +83,13 @@ setup(
                       #"pytest-server-fixtures", # must be manual
                       "pytest-cov",
                       "pytest",
+                      "pytest",
                       "pytz",
                       "tzlocal",
                       "lz4",
                      ],
     # Note: pytest >= 4.1.0 is not compatible with pytest-cov < 2.6.1.
-    # deprecated
+    # TODO why is this ignored by circleci
     tests_require=["mock",
                    "mockextras",
                    "pytest",

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
                       "lz4",
                      ],
     # Note: pytest >= 4.1.0 is not compatible with pytest-cov < 2.6.1.
-    # TODO why is this ignored by circleci
+    # Note: tests_require is deprecated
     tests_require=["mock",
                    "mockextras",
                    "pytest",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ class PyTest(TestCommand):
 
 setup(
     name="arctic",
-    version="1.80.0",
+    version="1.80.1",
     author="Man AHL Technology",
     author_email="ManAHLTech@ahl.com",
     description=("AHL Research Versioned TimeSeries and Tick store"),
@@ -75,24 +75,21 @@ setup(
                    ],
     install_requires=["decorator",
                       "enum-compat",
-                      #"enum34", # errors
-                      #"futures; python_version == '2.7'",
+                      #"enum34",
                       "mock",
                       "mockextras",
-                      # OK "pandas<=0.22.0",
-                      "pandas<=1.0.3", # original travis check_freq not found
+                      "pandas<=1.0.3",
                       "numpy<=1.18.4",
-                      #"pandas<=1.1.5", # green build 3.6/3.7
-                      "pymongo>=3.6.0",# green build 3.6/3.7
+                      "pymongo>=3.6.0, <= 3.11.0"
                       #"pytest-server-fixtures", # must be manual
-                      "pytest-cov", # uninstalls pytest do it first. also pulls in pytest-server-fixtures
+                      "pytest-cov",
                       "pytest",
                       "pytz",
                       "tzlocal",
                       "lz4",
                      ],
     # Note: pytest >= 4.1.0 is not compatible with pytest-cov < 2.6.1.
-    # TODO why is this ignored
+    # deprecated
     tests_require=["mock",
                    "mockextras",
                    "pytest",
@@ -116,7 +113,6 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 Man AHL
+# Copyright (C) 2015-2021 Man Group Ltd
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -75,16 +75,24 @@ setup(
                    ],
     install_requires=["decorator",
                       "enum-compat",
-                      "futures; python_version == '2.7'",
+                      #"enum34", # errors
+                      #"futures; python_version == '2.7'",
+                      "mock",
                       "mockextras",
-                      "pandas<=1.0.3",
-                      "pymongo>=3.6.0",
-                      "python-dateutil",
+                      # OK "pandas<=0.22.0",
+                      "pandas<=1.0.3", # original travis check_freq not found
+                      "numpy<=1.18.4",
+                      #"pandas<=1.1.5", # green build 3.6/3.7
+                      "pymongo>=3.6.0",# green build 3.6/3.7
+                      #"pytest-server-fixtures", # must be manual
+                      "pytest-cov", # uninstalls pytest do it first. also pulls in pytest-server-fixtures
+                      "pytest",
                       "pytz",
                       "tzlocal",
-                      "lz4"
+                      "lz4",
                      ],
     # Note: pytest >= 4.1.0 is not compatible with pytest-cov < 2.6.1.
+    # TODO why is this ignored
     tests_require=["mock",
                    "mockextras",
                    "pytest",
@@ -109,9 +117,8 @@ setup(
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Operating System :: POSIX",
         "Operating System :: MacOS",

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
                    ],
     install_requires=["decorator",
                       "enum-compat",
+                      #"enum34",
                       "mock",
                       "mockextras",
                       "pandas<=1.0.3",
@@ -83,13 +84,12 @@ setup(
                       #"pytest-server-fixtures", # must be manual
                       "pytest-cov",
                       "pytest",
-                      "pytest",
                       "pytz",
                       "tzlocal",
                       "lz4",
                      ],
     # Note: pytest >= 4.1.0 is not compatible with pytest-cov < 2.6.1.
-    # Note: tests_require is deprecated
+    # deprecated
     tests_require=["mock",
                    "mockextras",
                    "pytest",

--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -15,27 +15,28 @@ from arctic.chunkstore.passthrough_chunker import PassthroughChunker
 from arctic.date import DateRange
 from arctic.exceptions import NoDataFoundException
 from tests.integration.chunkstore.test_utils import create_test_data
+from tests.util import assert_frame_equal_
 
 
 def test_write_dataframe(chunkstore_lib):
     df = create_test_data()
     chunkstore_lib.write('test_df', df, chunk_size='D')
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)
 
 
 def test_upsert_dataframe(chunkstore_lib):
     df = create_test_data()
     chunkstore_lib.update('test_df', df, upsert=True)
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)
 
 
 def test_write_dataframe_noindex(chunkstore_lib):
     df = create_test_data(index=False)
     chunkstore_lib.write('test_df', df)
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)
 
 
 def test_overwrite_dataframe(chunkstore_lib):
@@ -45,7 +46,7 @@ def test_overwrite_dataframe(chunkstore_lib):
     chunkstore_lib.write('test_df', df)
     chunkstore_lib.write('test_df', dg)
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(dg, read_df)
+    assert_frame_equal_(dg, read_df)
 
 
 def test_overwrite_dataframe_noindex(chunkstore_lib):
@@ -56,7 +57,7 @@ def test_overwrite_dataframe_noindex(chunkstore_lib):
     chunkstore_lib.write('test_df', df)
     chunkstore_lib.write('test_df', df2)
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df2, read_df)
+    assert_frame_equal_(df2, read_df)
 
 
 def test_overwrite_dataframe_monthly(chunkstore_lib):
@@ -66,7 +67,7 @@ def test_overwrite_dataframe_monthly(chunkstore_lib):
     chunkstore_lib.write('test_df', df, chunk_size='M')
     chunkstore_lib.write('test_df', dg, chunk_size='M')
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(dg, read_df)
+    assert_frame_equal_(dg, read_df)
 
 
 def test_write_read_with_daterange(chunkstore_lib):
@@ -76,9 +77,9 @@ def test_write_read_with_daterange(chunkstore_lib):
     chunkstore_lib.write('test_df', df)
     read_df = chunkstore_lib.read('test_df', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 2)))
 
-    assert_frame_equal(read_df, dg)
+    assert_frame_equal_(read_df, dg)
     read_with_dr = chunkstore_lib.read('test_df', chunk_range=pd.date_range(dt(2016, 1, 1), dt(2016, 1, 2)))
-    assert_frame_equal(read_with_dr, dg)
+    assert_frame_equal_(read_with_dr, dg)
 
 
 def test_write_read_with_daterange_noindex(chunkstore_lib):
@@ -87,14 +88,14 @@ def test_write_read_with_daterange_noindex(chunkstore_lib):
 
     chunkstore_lib.write('test_df', df)
     read_df = chunkstore_lib.read('test_df', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 2)))
-    assert_frame_equal(read_df, dg)
+    assert_frame_equal_(read_df, dg)
 
 def test_store_single_index_df(chunkstore_lib):
     df = create_test_data(size=3, multiindex=False, index=True)
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3)))
-    assert_frame_equal(df, ret)
+    assert_frame_equal_(df, ret)
 
 
 def test_no_range(chunkstore_lib):
@@ -102,7 +103,7 @@ def test_no_range(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     ret = chunkstore_lib.read('chunkstore_test')
-    assert_frame_equal(df, ret)
+    assert_frame_equal_(df, ret)
 
 
 def test_closed_open(chunkstore_lib):
@@ -110,7 +111,7 @@ def test_closed_open(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), None))
-    assert_frame_equal(df, ret)
+    assert_frame_equal_(df, ret)
 
 
 def test_open_closed(chunkstore_lib):
@@ -118,7 +119,7 @@ def test_open_closed(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(None, dt(2017, 1, 1)))
-    assert_frame_equal(df, ret)
+    assert_frame_equal_(df, ret)
 
 
 def test_closed_open_no_index(chunkstore_lib):
@@ -126,7 +127,7 @@ def test_closed_open_no_index(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), None))
-    assert_frame_equal(df, ret)
+    assert_frame_equal_(df, ret)
 
 
 def test_open_open_no_index(chunkstore_lib):
@@ -134,7 +135,7 @@ def test_open_open_no_index(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(None, None))
-    assert_frame_equal(df, ret)
+    assert_frame_equal_(df, ret)
 
 
 def test_monthly_df(chunkstore_lib):
@@ -142,8 +143,8 @@ def test_monthly_df(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='M')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 2)))
-    assert_frame_equal(ret, df[dt(2016, 1, 1):dt(2016, 1, 2)])
-    assert_frame_equal(df, chunkstore_lib.read('chunkstore_test'))
+    assert_frame_equal_(ret, df[dt(2016, 1, 1):dt(2016, 1, 2)])
+    assert_frame_equal_(df, chunkstore_lib.read('chunkstore_test'))
 
 
 def test_yearly_df(chunkstore_lib):
@@ -151,7 +152,7 @@ def test_yearly_df(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='A')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 3, 3)))
-    assert_frame_equal(df[dt(2016, 1, 1):dt(2016, 3, 3)], ret)
+    assert_frame_equal_(df[dt(2016, 1, 1):dt(2016, 3, 3)], ret)
 
 
 def test_append_daily(chunkstore_lib):
@@ -161,7 +162,7 @@ def test_append_daily(chunkstore_lib):
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     chunkstore_lib.append('chunkstore_test', df2)
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 20)))
-    assert_frame_equal(ret, pd.concat([df, df2]))
+    assert_frame_equal_(ret, pd.concat([df, df2]))
 
 
 def test_append_monthly(chunkstore_lib):
@@ -171,7 +172,7 @@ def test_append_monthly(chunkstore_lib):
     chunkstore_lib.write('chunkstore_test', df, chunk_size='M')
     chunkstore_lib.append('chunkstore_test', df2)
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 12, 31)))
-    assert_frame_equal(ret, pd.concat([df, df2]))
+    assert_frame_equal_(ret, pd.concat([df, df2]))
 
 
 def test_append_yearly(chunkstore_lib):
@@ -181,7 +182,7 @@ def test_append_yearly(chunkstore_lib):
     chunkstore_lib.write('chunkstore_test', df, chunk_size='A')
     chunkstore_lib.append('chunkstore_test', df2)
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2000, 1, 1), dt(2100, 12, 31)))
-    assert_frame_equal(ret, pd.concat([df, df2]))
+    assert_frame_equal_(ret, pd.concat([df, df2]))
 
 
 def test_append_existing_chunk(chunkstore_lib):
@@ -191,7 +192,7 @@ def test_append_existing_chunk(chunkstore_lib):
     chunkstore_lib.write('chunkstore_test', df, chunk_size='M')
     chunkstore_lib.append('chunkstore_test', df2)
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 31)))
-    assert_frame_equal(ret, pd.concat([df, df2]))
+    assert_frame_equal_(ret, pd.concat([df, df2]))
 
 
 def test_store_objects_df(chunkstore_lib):
@@ -204,7 +205,7 @@ def test_store_objects_df(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     ret = chunkstore_lib.read('chunkstore_test', chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3)))
-    assert_frame_equal(df, ret)
+    assert_frame_equal_(df, ret)
 
 
 def test_empty_range(chunkstore_lib):
@@ -232,7 +233,7 @@ def test_update(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     chunkstore_lib.update('chunkstore_test', df2)
-    assert_frame_equal(chunkstore_lib.read('chunkstore_test'), equals)
+    assert_frame_equal_(chunkstore_lib.read('chunkstore_test'), equals)
     assert(chunkstore_lib.get_info('chunkstore_test')['len'] == len(equals))
     assert(chunkstore_lib.get_info('chunkstore_test')['chunk_count'] == len(equals))
 
@@ -257,7 +258,7 @@ def test_update_no_overlap(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     chunkstore_lib.update('chunkstore_test', df2)
-    assert_frame_equal(chunkstore_lib.read('chunkstore_test'), equals)
+    assert_frame_equal_(chunkstore_lib.read('chunkstore_test'), equals)
 
 
 def test_update_chunk_range(chunkstore_lib):
@@ -275,7 +276,7 @@ def test_update_chunk_range(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='M')
     chunkstore_lib.update('chunkstore_test', df2, chunk_range=DateRange(dt(2015, 1, 1), dt(2015, 1, 2)))
-    assert_frame_equal(chunkstore_lib.read('chunkstore_test'), equals)
+    assert_frame_equal_(chunkstore_lib.read('chunkstore_test'), equals)
 
 
 def test_update_chunk_range_overlap(chunkstore_lib):
@@ -286,7 +287,7 @@ def test_update_chunk_range_overlap(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='M')
     chunkstore_lib.update('chunkstore_test', df, chunk_range=DateRange(dt(2015, 1, 1), dt(2015, 1, 3)))
-    assert_frame_equal(chunkstore_lib.read('chunkstore_test'), df)
+    assert_frame_equal_(chunkstore_lib.read('chunkstore_test'), df)
 
 
 def test_append_before(chunkstore_lib):
@@ -309,7 +310,7 @@ def test_append_before(chunkstore_lib):
 
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     chunkstore_lib.append('chunkstore_test', df2)
-    assert_frame_equal(chunkstore_lib.read('chunkstore_test') , equals)
+    assert_frame_equal_(chunkstore_lib.read('chunkstore_test') , equals)
 
 
 def test_append_and_update(chunkstore_lib):
@@ -337,7 +338,7 @@ def test_append_and_update(chunkstore_lib):
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     chunkstore_lib.append('chunkstore_test', df2)
     chunkstore_lib.update('chunkstore_test', df3)
-    assert_frame_equal(chunkstore_lib.read('chunkstore_test') , equals)
+    assert_frame_equal_(chunkstore_lib.read('chunkstore_test') , equals)
 
 
 def test_update_same_df(chunkstore_lib):
@@ -370,7 +371,7 @@ def test_with_strings(chunkstore_lib):
                                         dt(2016, 1, 3)], name='date'))
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     read_df = chunkstore_lib.read('chunkstore_test')
-    assert_frame_equal(read_df, df)
+    assert_frame_equal_(read_df, df)
 
 
 def test_with_strings_multiindex_append(chunkstore_lib):
@@ -381,7 +382,7 @@ def test_with_strings_multiindex_append(chunkstore_lib):
                                                 names=['date', 'security']))
     chunkstore_lib.write('chunkstore_test', df, chunk_size='D')
     read_df = chunkstore_lib.read('chunkstore_test')
-    assert_frame_equal(read_df, df)
+    assert_frame_equal_(read_df, df)
     df2 = DataFrame(data={'data': ['AAAAAAA']},
                     index=MultiIndex.from_tuples([(dt(2016, 1, 2), 4)],
                                                  names=['date', 'security']))
@@ -392,7 +393,7 @@ def test_with_strings_multiindex_append(chunkstore_lib):
                                                  (dt(2016, 1, 2), 2),
                                                  (dt(2016, 1, 2), 4)],
                                                 names=['date', 'security']))
-    assert_frame_equal(chunkstore_lib.read('chunkstore_test') , df)
+    assert_frame_equal_(chunkstore_lib.read('chunkstore_test') , df)
 
 
 def gen_daily_data(month, days, securities):
@@ -435,17 +436,17 @@ def test_multiple_actions(chunkstore_lib):
         written_df = write_random_data(chunkstore_lib, name, 1, list(range(1, 31)), list(range(1, 101)), chunk_size=chunk_size)
 
         read_info = chunkstore_lib.read(name)
-        assert_frame_equal(written_df, read_info)
+        assert_frame_equal_(written_df, read_info)
 
         df = write_random_data(chunkstore_lib, name, 1, list(range(1, 31)), list(range(1, 101)), chunk_size=chunk_size)
 
         read_info = chunkstore_lib.read(name)
-        assert_frame_equal(df, read_info)
+        assert_frame_equal_(df, read_info)
 
         r = read_info
         df = write_random_data(chunkstore_lib, name, 2, list(range(1, 29)), list(range(1, 501)), append=True, chunk_size=chunk_size)
         read_info = chunkstore_lib.read(name)
-        assert_frame_equal(pd.concat([r, df]), read_info)
+        assert_frame_equal_(pd.concat([r, df]), read_info)
 
     for chunk_size in ['D', 'M', 'A']:
         helper(chunkstore_lib, 'test_data_' + chunk_size, chunk_size)
@@ -456,20 +457,20 @@ def test_multiple_actions_monthly_data(chunkstore_lib):
         chunkstore_lib.write(name, df, chunk_size=chunk_size)
 
         r = chunkstore_lib.read(name)
-        assert_frame_equal(r, df)
+        assert_frame_equal_(r, df)
 
         chunkstore_lib.append(name, append)
 
-        assert_frame_equal(chunkstore_lib.read(name), pd.concat([df, append]))
+        assert_frame_equal_(chunkstore_lib.read(name), pd.concat([df, append]))
 
         chunkstore_lib.update(name, append)
 
         if chunk_size is not 'A':
-            assert_frame_equal(chunkstore_lib.read(name), pd.concat([df, append]))
+            assert_frame_equal_(chunkstore_lib.read(name), pd.concat([df, append]))
         else:
             # chunksize is the entire DF, so we'll overwrite the whole thing
             # with the update when its yearly chunking
-            assert_frame_equal(chunkstore_lib.read(name), append)
+            assert_frame_equal_(chunkstore_lib.read(name), append)
 
     df = []
     for month in range(1, 4):
@@ -496,7 +497,7 @@ def test_delete(chunkstore_lib):
                    )
     chunkstore_lib.write('test_df', df)
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)
     assert ('test_df' in chunkstore_lib.list_symbols())
     chunkstore_lib.delete('test_df')
     assert (chunkstore_lib.list_symbols() == [])
@@ -511,10 +512,10 @@ def test_delete_empty_df_on_range(chunkstore_lib):
                    )
     chunkstore_lib.write('test_df', df)
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)
     assert ('test_df' in chunkstore_lib.list_symbols())
     chunkstore_lib.delete('test_df', chunk_range=DateRange(dt(2017, 1, 1), dt(2017, 1, 2)))
-    assert_frame_equal(df, chunkstore_lib.read('test_df'))
+    assert_frame_equal_(df, chunkstore_lib.read('test_df'))
 
 
 def test_get_info(chunkstore_lib):
@@ -551,7 +552,7 @@ def test_get_info_after_append(chunkstore_lib):
                                                  names=['date', 'id'])
                     )
     chunkstore_lib.append('test_df', df2)
-    assert_frame_equal(chunkstore_lib.read('test_df'), pd.concat([df, df2]).sort_index())
+    assert_frame_equal_(chunkstore_lib.read('test_df'), pd.concat([df, df2]).sort_index())
 
     info = {'len': 6,
             'appended_rows': 2,
@@ -612,7 +613,7 @@ def test_delete_range(chunkstore_lib):
 
     chunkstore_lib.write('test', df, chunk_size='M')
     chunkstore_lib.delete('test', chunk_range=DateRange(dt(2016, 1, 2), dt(2016, 3, 1)))
-    assert_frame_equal(chunkstore_lib.read('test'), df_result)
+    assert_frame_equal_(chunkstore_lib.read('test'), df_result)
     assert(chunkstore_lib.get_info('test')['len'] == len(df_result))
     assert(chunkstore_lib.get_info('test')['chunk_count'] == 2)
 
@@ -632,7 +633,7 @@ def test_delete_range_noindex(chunkstore_lib):
 
     chunkstore_lib.write('test', df, chunk_size='M')
     chunkstore_lib.delete('test', chunk_range=DateRange(dt(2016, 1, 2), dt(2016, 3, 1)))
-    assert_frame_equal(chunkstore_lib.read('test'), df_result)
+    assert_frame_equal_(chunkstore_lib.read('test'), df_result)
 
 
 def test_read_chunk_range(chunkstore_lib):
@@ -658,7 +659,7 @@ def test_read_chunk_range(chunkstore_lib):
     assert(len(chunkstore_lib.read('test', chunk_range=DateRange(dt(2016, 2, 2), dt(2016, 2, 2)), filter_data=False)) == 3)
 
     df2 = chunkstore_lib.read('test', chunk_range=DateRange(None, None))
-    assert_frame_equal(df, df2)
+    assert_frame_equal_(df, df2)
 
 
 def test_read_data_doesnt_exist(chunkstore_lib):
@@ -693,7 +694,7 @@ def test_append_upsert(chunkstore_lib):
                                                 names=['date', 'id'])
                    )
     chunkstore_lib.append('some_data', df, upsert=True)
-    assert_frame_equal(df, chunkstore_lib.read('some_data'))
+    assert_frame_equal_(df, chunkstore_lib.read('some_data'))
 
 
 def test_append_no_new_data(chunkstore_lib):
@@ -702,7 +703,7 @@ def test_append_no_new_data(chunkstore_lib):
     chunkstore_lib.write('test', df)
     chunkstore_lib.append('test', df)
     r = chunkstore_lib.read('test')
-    assert_frame_equal(pd.concat([df, df]).sort_index(), r)
+    assert_frame_equal_(pd.concat([df, df]).sort_index(), r)
 
 
 def test_overwrite_series(chunkstore_lib):
@@ -836,19 +837,19 @@ def test_read_column_subset(chunkstore_lib):
     chunkstore_lib.write('test', df, chunk_size='Y')
     r = chunkstore_lib.read('test', columns=cols)
     assert cols == ['prev_close', 'volume']
-    assert_frame_equal(r, df[cols])
+    assert_frame_equal_(r, df[cols])
 
-    assert_frame_equal(df[cols], next(chunkstore_lib.iterator('test', columns=cols)))
-    assert_frame_equal(df[cols], next(chunkstore_lib.reverse_iterator('test', columns=cols)))
+    assert_frame_equal_(df[cols], next(chunkstore_lib.iterator('test', columns=cols)))
+    assert_frame_equal_(df[cols], next(chunkstore_lib.reverse_iterator('test', columns=cols)))
 
 
 def test_rename(chunkstore_lib):
     df = create_test_data(size=10, cols=5)
 
     chunkstore_lib.write('test', df, chunk_size='D')
-    assert_frame_equal(chunkstore_lib.read('test'), df)
+    assert_frame_equal_(chunkstore_lib.read('test'), df)
     chunkstore_lib.rename('test', 'new_name')
-    assert_frame_equal(chunkstore_lib.read('new_name'), df)
+    assert_frame_equal_(chunkstore_lib.read('new_name'), df)
 
     with pytest.raises(Exception) as e:
         chunkstore_lib.rename('new_name', 'new_name')
@@ -873,7 +874,7 @@ def test_pass_thru_chunker(chunkstore_lib):
 
     chunkstore_lib.write('test_df', df, chunker=PassthroughChunker())
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)
 
 
 def test_pass_thru_chunker_append(chunkstore_lib):
@@ -884,7 +885,7 @@ def test_pass_thru_chunker_append(chunkstore_lib):
     chunkstore_lib.append('test_df', df2)
     read_df = chunkstore_lib.read('test_df')
 
-    assert_frame_equal(pd.concat([df, df2], ignore_index=True), read_df)
+    assert_frame_equal_(pd.concat([df, df2], ignore_index=True), read_df)
 
 
 def test_pass_thru_chunker_update(chunkstore_lib):
@@ -895,7 +896,7 @@ def test_pass_thru_chunker_update(chunkstore_lib):
     chunkstore_lib.update('test_df', df2)
     read_df = chunkstore_lib.read('test_df')
 
-    assert_frame_equal(df2, read_df)
+    assert_frame_equal_(df2, read_df)
 
 
 def test_pass_thru_chunker_update_range(chunkstore_lib):
@@ -906,7 +907,7 @@ def test_pass_thru_chunker_update_range(chunkstore_lib):
     chunkstore_lib.update('test_df', df2, chunk_range="")
     read_df = chunkstore_lib.read('test_df')
 
-    assert_frame_equal(read_df, df2)
+    assert_frame_equal_(read_df, df2)
 
 
 def test_size_chunking(chunkstore_lib):
@@ -915,7 +916,7 @@ def test_size_chunking(chunkstore_lib):
 
     chunkstore_lib.write('test_df', df)
     read_df = chunkstore_lib.read('test_df')
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)
 
 
 def test_size_chunk_append(chunkstore_lib):
@@ -927,7 +928,7 @@ def test_size_chunk_append(chunkstore_lib):
     chunkstore_lib.append('test_df', dg)
     read_df = chunkstore_lib.read('test_df')
 
-    assert_frame_equal(pd.concat([df, dg], ignore_index=True), read_df)
+    assert_frame_equal_(pd.concat([df, dg], ignore_index=True), read_df)
 
 
 def test_delete_range_segment(chunkstore_lib):
@@ -942,7 +943,7 @@ def test_delete_range_segment(chunkstore_lib):
     chunkstore_lib.write('test_df', pd.concat([df, dg], ignore_index=True), chunk_size='M')
     chunkstore_lib.delete('test_df', chunk_range=pd.date_range(dt(2016, 1, 1), dt(2016, 1, 1)))
     read_df = chunkstore_lib.read('test_df')
-    assert(read_df.equals(dg))
+    assert_frame_equal_(read_df, dg)
     assert(mongo_count(chunkstore_lib._collection, {'sy': 'test_df'}) == 1)
 
 
@@ -959,7 +960,7 @@ def test_size_chunk_update(chunkstore_lib):
 
     read_df = chunkstore_lib.read('test_df')
 
-    assert_frame_equal(dh, read_df)
+    assert_frame_equal_(dh, read_df)
     assert mongo_count(chunkstore_lib._collection, filter={'sy': 'test_df'}) == 1
 
 
@@ -975,7 +976,7 @@ def test_size_chunk_multiple_update(chunkstore_lib):
 
     expected = pd.concat([df_large, df_small]).reset_index(drop=True)
 
-    assert_frame_equal(expected, read_df)
+    assert_frame_equal_(expected, read_df)
     assert mongo_count(chunkstore_lib._collection, filter={'sy': 'test_df'}) == 3
 
 
@@ -1034,7 +1035,7 @@ def test_quarterly_data(chunkstore_lib):
     df.index.name = 'date'
 
     chunkstore_lib.write('quarterly', df, chunk_size='Q')
-    assert_frame_equal(df, chunkstore_lib.read('quarterly'))
+    assert_frame_equal_(df, chunkstore_lib.read('quarterly'), check_freq=False)
     assert(len(chunkstore_lib.read('quarterly', chunk_range=(None, '2016-01-05'))) == 5)
     count = 0
     for _ in chunkstore_lib._collection.find({SYMBOL: 'quarterly'}, sort=[(START, pymongo.ASCENDING)],):
@@ -1186,9 +1187,9 @@ def test_unsorted_index(chunkstore_lib):
                         'vals': range(2)}).set_index('date')
 
     chunkstore_lib.write('test_symbol', df)
-    assert_frame_equal(df.sort_index(), chunkstore_lib.read('test_symbol'))
+    assert_frame_equal_(df.sort_index(), chunkstore_lib.read('test_symbol'))
     chunkstore_lib.update('test_symbol', df2)
-    assert_frame_equal(chunkstore_lib.read('test_symbol'),
+    assert_frame_equal_(chunkstore_lib.read('test_symbol'),
                        pd.DataFrame({'date': pd.date_range('2016-8-31',
                                                            '2016-9-2'),
                                      'vals': [1, 1, 0]}).set_index('date'))
@@ -1204,9 +1205,9 @@ def test_unsorted_date_col(chunkstore_lib):
         df = df.sort_values('date')
     except AttributeError:
         df = df.sort(columns='date')
-    assert_frame_equal(df.reset_index(drop=True), chunkstore_lib.read('test_symbol'))
+    assert_frame_equal_(df.reset_index(drop=True), chunkstore_lib.read('test_symbol'))
     chunkstore_lib.update('test_symbol', df2)
-    assert_frame_equal(chunkstore_lib.read('test_symbol'),
+    assert_frame_equal_(chunkstore_lib.read('test_symbol'),
                        pd.DataFrame({'date': pd.date_range('2016-8-31',
                                                            '2016-9-2'),
                                      'vals': [1, 1, 0]}))
@@ -1229,9 +1230,9 @@ def test_chunkstore_multiread(chunkstore_lib):
 
     ret = chunkstore_lib.read(['a', 'b', 'c'])
 
-    assert_frame_equal(df, ret['a'])
-    assert_frame_equal(df2, ret['b'])
-    assert_frame_equal(df3, ret['c'])
+    assert_frame_equal_(df, ret['a'])
+    assert_frame_equal_(df2, ret['b'])
+    assert_frame_equal_(df3, ret['c'])
 
 
 def test_chunkstore_multiread_samedate(chunkstore_lib):
@@ -1246,13 +1247,13 @@ def test_chunkstore_multiread_samedate(chunkstore_lib):
 
     ret = chunkstore_lib.read(['a', 'b', 'c'])
 
-    assert_frame_equal(df, ret['a'])
-    assert_frame_equal(df2, ret['b'])
-    assert_frame_equal(df3, ret['c'])
+    assert_frame_equal_(df, ret['a'])
+    assert_frame_equal_(df2, ret['b'])
+    assert_frame_equal_(df3, ret['c'])
 
     ret = chunkstore_lib.read(['a', 'b', 'c'], chunk_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 1)))
-    assert_frame_equal(df[:1], ret['a'])
-    assert_frame_equal(df2[:1], ret['b'])
+    assert_frame_equal_(df[:1], ret['a'])
+    assert_frame_equal_(df2[:1], ret['b'])
     assert(len(ret['c']) == 0)
 
 
@@ -1266,4 +1267,4 @@ def test_write_dataframe_with_func(chunkstore_lib):
     read_df = chunkstore_lib.read('test_df')
 
     df.loc[:, 'data0'] += 1.0
-    assert_frame_equal(df, read_df)
+    assert_frame_equal_(df, read_df)

--- a/tests/integration/chunkstore/test_fixes.py
+++ b/tests/integration/chunkstore/test_fixes.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex
 from pandas.util.testing import assert_frame_equal
+from tests.util import assert_frame_equal_
 
 from arctic.date import DateRange, CLOSED_OPEN, CLOSED_CLOSED, OPEN_OPEN, OPEN_CLOSED
 
@@ -58,7 +59,7 @@ def test_compression(chunkstore_lib):
     df2 = generate_data(date)
     chunkstore_lib.append('test', df2)
     read = chunkstore_lib.read('test')
-    assert_frame_equal(read, pd.concat([df, df2], ignore_index=True))
+    assert_frame_equal_(read, pd.concat([df, df2], ignore_index=True))
 
 
 # issue #420 - ChunkStore doesnt respect DateRange interval
@@ -72,15 +73,15 @@ def test_date_interval(chunkstore_lib):
     chunkstore_lib.write('test', df, chunk_size='D')
 
     ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017, 5, 2), dt(2017, 5, 5), CLOSED_OPEN))
-    assert_frame_equal(ret, df[1:4])
+    assert_frame_equal_(ret, df[1:4], check_freq=False)
     ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017, 5, 2), dt(2017, 5, 5), OPEN_OPEN))
-    assert_frame_equal(ret, df[2:4])
+    assert_frame_equal_(ret, df[2:4], check_freq=False)
     ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017, 5, 2), dt(2017, 5, 5), OPEN_CLOSED))
-    assert_frame_equal(ret, df[2:5])
+    assert_frame_equal_(ret, df[2:5], check_freq=False)
     ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017, 5, 2), dt(2017, 5, 5), CLOSED_CLOSED))
-    assert_frame_equal(ret, df[1:5])
+    assert_frame_equal_(ret, df[1:5], check_freq=False)
     ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017, 5, 2), None, CLOSED_OPEN))
-    assert_frame_equal(ret, df[1:8])
+    assert_frame_equal_(ret, df[1:8], check_freq=False)
 
     # test without index
     df = DataFrame(data={'data': range(8),
@@ -122,7 +123,7 @@ def test_rewrite(chunkstore_lib):
 
     chunkstore_lib.write('test', df2, chunk_size='D')
     ret = chunkstore_lib.read('test')
-    assert_frame_equal(ret, df2)
+    assert_frame_equal_(ret, df2)
 
 
 def test_iterator(chunkstore_lib):
@@ -163,9 +164,9 @@ def test_missing_cols(chunkstore_lib):
     chunkstore_lib.append('test', df, chunk_size='D')
 
 
-    assert_frame_equal(chunkstore_lib.read('test'), expected_df)
+    assert_frame_equal_(chunkstore_lib.read('test'), expected_df, check_freq=False)
     df = chunkstore_lib.read('test', columns=['B'])
-    assert_frame_equal(df, expected_df['B'].to_frame())
+    assert_frame_equal_(df, expected_df['B'].to_frame(), check_freq=False)
 
 
 def test_column_copy(chunkstore_lib):

--- a/tests/integration/chunkstore/test_utils.py
+++ b/tests/integration/chunkstore/test_utils.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from pandas import DataFrame, Index, MultiIndex
 from pandas.util.testing import assert_frame_equal
+from tests.util import assert_frame_equal_
 
 from arctic.chunkstore.utils import read_apply
 
@@ -37,4 +38,4 @@ def test_read_apply(chunkstore_lib):
         return df
 
     for data in read_apply(chunkstore_lib, 'test', func):
-        assert_frame_equal(data, func(df))
+        assert_frame_equal_(data, func(df))

--- a/tests/integration/chunkstore/tools/test_tools.py
+++ b/tests/integration/chunkstore/tools/test_tools.py
@@ -3,6 +3,7 @@ import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
 from arctic.chunkstore.tools import segment_id_repair
+from ..test_fixes import assert_frame_equal_
 
 
 def test_segment_repair_tool(chunkstore_lib):
@@ -48,7 +49,8 @@ def test_segment_repair_tool(chunkstore_lib):
     assert(get_segments() == [0, 1])
 
     read = chunkstore_lib.read('test')
-    assert_frame_equal(read, pd.concat([df, df2], ignore_index=True))
+
+    assert_frame_equal_(read, pd.concat([df, df2], ignore_index=True))
 
     chunkstore_lib._collection.update_one({'sy': 'test', 'sg': 0}, {'$set': {'sg': -1}})
     chunkstore_lib._collection.update_one({'sy': 'test', 'sg': 1}, {'$set': {'sg': 0}})
@@ -58,5 +60,5 @@ def test_segment_repair_tool(chunkstore_lib):
     assert(get_segments() == [0, 1])
     assert(symbols == ['test'])
 
-    assert_frame_equal(chunkstore_lib.read('more_data'), more_data)
-    assert_frame_equal(chunkstore_lib.read('other_data'), other_data)
+    assert_frame_equal_(chunkstore_lib.read('more_data'), more_data)
+    assert_frame_equal_(chunkstore_lib.read('other_data'), other_data)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -22,6 +22,7 @@ from arctic.date import DateRange, mktz
 # Do not remove PandasStore, used in global scope
 from arctic.store._pandas_ndarray_store import PandasDataFrameStore, PandasSeriesStore, PandasStore
 from arctic.store.version_store import register_versioned_storage
+from tests.util import assert_frame_equal_
 
 register_versioned_storage(PandasDataFrameStore)
 
@@ -804,31 +805,31 @@ def test_daterange_large_DataFrame(library):
     library.write('MYARR', df)
     # assert saved
     saved_arr = library.read('MYARR').data
-    assert_frame_equal(df, saved_arr, check_names=False)
+    assert_frame_equal_(df, saved_arr, check_names=False, check_freq=False)
     # first 100
     result = library.read('MYARR', date_range=DateRange(df.index[0], df.index[100])).data
-    assert_frame_equal(df[df.index[0]:df.index[100]], result, check_names=False)
+    assert_frame_equal_(df[df.index[0]:df.index[100]], result, check_names=False, check_freq=False)
     # second 100
     result = library.read('MYARR', date_range=DateRange(df.index[100], df.index[200])).data
-    assert_frame_equal(df[df.index[100]:df.index[200]], result, check_names=False)
+    assert_frame_equal_(df[df.index[100]:df.index[200]], result, check_names=False, check_freq=False)
     # first row
     result = library.read('MYARR', date_range=DateRange(df.index[0], df.index[0])).data
-    assert_frame_equal(df[df.index[0]:df.index[0]], result, check_names=False)
+    assert_frame_equal_(df[df.index[0]:df.index[0]], result, check_names=False, check_freq=False)
     # last 100
     result = library.read('MYARR', date_range=DateRange(df.index[-100])).data
-    assert_frame_equal(df[df.index[-100]:], result, check_names=False)
+    assert_frame_equal_(df[df.index[-100]:], result, check_names=False, check_freq=False)
     # last 200-100
     result = library.read('MYARR', date_range=DateRange(df.index[-200], df.index[-100])).data
-    assert_frame_equal(df[df.index[-200]:df.index[-100]], result, check_names=False)
+    assert_frame_equal_(df[df.index[-200]:df.index[-100]], result, check_names=False, check_freq=False)
     # last row
     result = library.read('MYARR', date_range=DateRange(df.index[-1], df.index[-1])).data
-    assert_frame_equal(df[df.index[-1]:df.index[-1]], result, check_names=False)
+    assert_frame_equal_(df[df.index[-1]:df.index[-1]], result, check_names=False, check_freq=False)
     # beyond last row
     result = library.read('MYARR', date_range=DateRange(df.index[-1], df.index[-1] + dtd(days=1))).data
-    assert_frame_equal(df[df.index[-1]:df.index[-1]], result, check_names=False)
+    assert_frame_equal_(df[df.index[-1]:df.index[-1]], result, check_names=False, check_freq=False)
     # somewhere in time
     result = library.read('MYARR', date_range=DateRange(dt(2020, 1, 1), dt(2031, 9, 1))).data
-    assert_frame_equal(df[dt(2020, 1, 1):dt(2031, 9, 1)], result, check_names=False)
+    assert_frame_equal_(df[dt(2020, 1, 1):dt(2031, 9, 1)], result, check_names=False, check_freq=False)
 
 
 def test_daterange_large_DataFrame_middle(library):
@@ -840,13 +841,13 @@ def test_daterange_large_DataFrame_middle(library):
     start = 100
     for end in np.arange(200, 30000, 1000):
         result = library.read('MYARR', date_range=DateRange(df.index[start], df.index[end])).data
-        assert_frame_equal(df[df.index[start]:df.index[end]], result, check_names=False)
+        assert_frame_equal_(df[df.index[start]:df.index[end]], result, check_names=False, check_freq=False)
     # middle following
     for start in np.arange(200, 30000, 1000):
         for offset in (100, 300, 500):
             end = start + offset
             result = library.read('MYARR', date_range=DateRange(df.index[start], df.index[end])).data
-            assert_frame_equal(df[df.index[start]:df.index[end]], result, check_names=False)
+            assert_frame_equal_(df[df.index[start]:df.index[end]], result, check_names=False, check_freq=False)
 
 
 @pytest.mark.parametrize("df,assert_equal", [
@@ -887,21 +888,21 @@ def test_daterange_append(library):
     library.write('MYARR', df)
     # assert saved
     saved_arr = library.read('MYARR').data
-    assert_frame_equal(df, saved_arr, check_names=False)
+    assert_frame_equal_(df, saved_arr, check_names=False, check_freq=False)
     # append two more rows
     rows = df.iloc[-2:].copy()
     rows.index = rows.index + dtd(days=1)
     library.append('MYARR', rows)
     # assert we can rows back out
-    assert_frame_equal(rows, library.read('MYARR', date_range=DateRange(rows.index[0])).data)
+    assert_frame_equal_(rows, library.read('MYARR', date_range=DateRange(rows.index[0])).data, check_freq=False)
     # assert we can read back the first array
-    assert_frame_equal(df, library.read('MYARR', date_range=DateRange(df.index[0], df.index[-1])).data)
+    assert_frame_equal_(df, library.read('MYARR', date_range=DateRange(df.index[0], df.index[-1])).data, check_freq=False)
     # append two more rows
     rows1 = df.iloc[-2:].copy()
     rows1.index = rows1.index + dtd(days=2)
     library.append('MYARR', rows1)
     # assert we can read a mix of data
-    assert_frame_equal(rows1, library.read('MYARR', date_range=DateRange(rows1.index[0])).data)
+    assert_frame_equal_(rows1, library.read('MYARR', date_range=DateRange(rows1.index[0])).data, check_freq=False)
     assert_frame_equal(concat((df, rows, rows1)), library.read('MYARR').data)
     assert_frame_equal(concat((rows, rows1)), library.read('MYARR', date_range=DateRange(start=rows.index[0])).data)
     assert_frame_equal(concat((df, rows, rows1))[df.index[50]:rows1.index[-2]],

--- a/tests/integration/store/test_version_store.py
+++ b/tests/integration/store/test_version_store.py
@@ -27,6 +27,7 @@ from arctic.store import version_store
 from tests.unit.serialization.serialization_test_data import _mixed_test_data
 from ...util import read_str_as_pandas
 from ..test_utils import enable_profiling_for_library
+from tests.util import assert_frame_equal_
 
 ts1 = read_str_as_pandas("""         times | near
                    2012-09-08 17:06:11.040 |  1.0
@@ -168,7 +169,7 @@ def test_store_item_metadata(library, fw_pointers_cfg):
 
         assert after.metadata['key'] == 'value'
         assert after.version
-        assert_frame_equal(after.data, ts1)
+        assert_frame_equal_(after.data, ts1)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -230,7 +231,7 @@ def test_store_item_and_update(library, fw_pointers_cfg):
 
         # Assertions:
         assert mongo_count(coll.versions) == 1
-        assert_frame_equal(library.read(symbol).data, ts1)
+        assert_frame_equal_(library.read(symbol).data, ts1)
 
         # Update the TimeSeries
         time.sleep(1)
@@ -238,27 +239,27 @@ def test_store_item_and_update(library, fw_pointers_cfg):
         recent = datetime.now()
 
         assert mongo_count(coll.versions) == 2
-        assert_frame_equal(library.read(symbol).data, ts2)
+        assert_frame_equal_(library.read(symbol).data, ts2)
 
         # Get the different versions of the DB
         with pytest.raises(NoDataFoundException):
             library.read(symbol, as_of=none)
-        assert_frame_equal(library.read(symbol, as_of=original).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=recent).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=original).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=recent).data, ts2)
 
         # Now push back in the original version
         time.sleep(1)
         library.write(symbol, ts1, prune_previous_version=False)
 
         assert mongo_count(coll.versions) == 3
-        assert_frame_equal(library.read(symbol).data, ts1)
+        assert_frame_equal_(library.read(symbol).data, ts1)
 
         # Get the different versions of the DB
         with pytest.raises(NoDataFoundException):
             library.read(symbol, as_of=none)
-        assert_frame_equal(library.read(symbol, as_of=original).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=recent).data, ts2)
-        assert_frame_equal(library.read(symbol, as_of=datetime.now()).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=original).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=recent).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=datetime.now()).data, ts1)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -271,7 +272,7 @@ def test_append_update(library, fw_pointers_cfg):
 
         # Assertions:
         assert mongo_count(coll.versions) == 1
-        assert_frame_equal(library.read(symbol).data, ts1)
+        assert_frame_equal_(library.read(symbol).data, ts1)
 
         # Append an item
         dts = list(ts1.index)
@@ -285,16 +286,16 @@ def test_append_update(library, fw_pointers_cfg):
         # reuse the last chunk.
         library.write(symbol, ts2, prune_previous_version=False)
         assert mongo_count(coll.versions) == 2
-        assert_frame_equal(library.read(symbol, as_of='snap').data, ts1)
-        assert_frame_equal(library.read(symbol).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of='snap').data, ts1)
+        assert_frame_equal_(library.read(symbol).data, ts2)
 
         # We should be able to save a smaller timeseries too
         # This isn't likely to happen, so we don't care too much about space saving
         # just make sure we get it right.
         library.write(symbol, ts1, prune_previous_version=False)
-        assert_frame_equal(library.read(symbol, as_of=1).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=2).data, ts2)
-        assert_frame_equal(library.read(symbol, as_of=3).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=1).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=2).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=3).data, ts1)
 
         # Append an item, and add a whole new chunk
         dts = list(ts2.index)
@@ -307,17 +308,17 @@ def test_append_update(library, fw_pointers_cfg):
         ts3.index.name = ts1.index.name
 
         library.write(symbol, ts3, prune_previous_version=False)
-        assert_frame_equal(library.read(symbol, as_of=1).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=2).data, ts2)
-        assert_frame_equal(library.read(symbol, as_of=3).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=4).data, ts3)
+        assert_frame_equal_(library.read(symbol, as_of=1).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=2).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=3).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, ts3)
 
         library.write(symbol, ts3, prune_previous_version=False)
-        assert_frame_equal(library.read(symbol, as_of=1).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=2).data, ts2)
-        assert_frame_equal(library.read(symbol, as_of=3).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=4).data, ts3)
-        assert_frame_equal(library.read(symbol, as_of=5).data, ts3)
+        assert_frame_equal_(library.read(symbol, as_of=1).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=2).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=3).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, ts3)
+        assert_frame_equal_(library.read(symbol, as_of=5).data, ts3)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -373,8 +374,8 @@ def test_query_version_as_of_int(library):
     library.write(symbol, ts1)
     library.write(symbol, ts2, prune_previous_version=False)
 
-    assert_frame_equal(library.read(symbol, as_of=1).data, ts1)
-    assert_frame_equal(library.read(symbol).data, ts2)
+    assert_frame_equal_(library.read(symbol, as_of=1).data, ts1)
+    assert_frame_equal_(library.read(symbol).data, ts2)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -481,15 +482,15 @@ def test_delete_versions(library, fw_pointers_cfg):
 
         # Delete version 1 (ts1)
         library._delete_version(symbol, 1)
-        assert_frame_equal(library.read(symbol, as_of=2).data, ts2)
-        assert_frame_equal(library.read(symbol, as_of=3).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=2).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=3).data, ts1)
 
         library._delete_version(symbol, 2)
-        assert_frame_equal(library.read(symbol, as_of=3).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=4).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=3).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, ts2)
 
         library._delete_version(symbol, 3)
-        assert_frame_equal(library.read(symbol).data, ts2)
+        assert_frame_equal_(library.read(symbol).data, ts2)
 
         library._delete_version(symbol, 4)
         assert mongo_count(coll) == 0
@@ -568,8 +569,8 @@ def test_delete_item_snapshot(library, fw_pointers_cfg):
                 library.read(symbol, version)
 
         # Can get the version out of the snapshots
-        assert_frame_equal(library.read(symbol, 'snap').data, ts1)
-        assert_frame_equal(library.read(symbol, 3).data, ts1)
+        assert_frame_equal_(library.read(symbol, 'snap').data, ts1)
+        assert_frame_equal_(library.read(symbol, 3).data, ts1)
 
         assert not library.has_symbol(symbol)
         assert not library.has_symbol(symbol, as_of=2)
@@ -583,7 +584,7 @@ def test_delete_item_snapshot(library, fw_pointers_cfg):
         library.snapshot('snap2')
         with pytest.raises(NoDataFoundException):
             library.read(symbol, 'snap2')
-        assert_frame_equal(library.read(symbol, 'snap').data, ts1)
+        assert_frame_equal_(library.read(symbol, 'snap').data, ts1)
         assert symbol in library.list_symbols(snapshot='snap')
         assert symbol not in library.list_symbols(snapshot='snap2')
 
@@ -600,25 +601,25 @@ def test_snapshot(library, fw_pointers_cfg):
         library.write(symbol, ts1)
         library.snapshot('current')
         library.write(symbol, ts2)
-        assert_frame_equal(library.read(symbol, as_of='current').data, ts1)
-        assert_frame_equal(library.read(symbol).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of='current').data, ts1)
+        assert_frame_equal_(library.read(symbol).data, ts2)
         versions = library.list_versions(symbol)
         assert versions[0]['snapshots'] == []
         assert versions[1]['snapshots'] == ['current']
 
         library.snapshot('new')
-        assert_frame_equal(library.read(symbol, as_of='current').data, ts1)
-        assert_frame_equal(library.read(symbol, as_of='new').data, ts2)
-        assert_frame_equal(library.read(symbol).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of='current').data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of='new').data, ts2)
+        assert_frame_equal_(library.read(symbol).data, ts2)
         versions = library.list_versions(symbol)
         assert versions[0]['snapshots'] == ['new']
         assert versions[1]['snapshots'] == ['current']
 
         # Replace the current version, and the snapshot shouldn't be deleted
         library.write(symbol, ts1, prune_previous_version=True)
-        assert_frame_equal(library.read(symbol, as_of='current').data, ts1)
-        assert_frame_equal(library.read(symbol, as_of='new').data, ts2)
-        assert_frame_equal(library.read(symbol).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of='current').data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of='new').data, ts2)
+        assert_frame_equal_(library.read(symbol).data, ts1)
         versions = library.list_versions(symbol)
         assert versions[0]['snapshots'] == []
         assert versions[1]['snapshots'] == ['new']
@@ -637,18 +638,18 @@ def test_snapshot_with_versions(library, fw_pointers_cfg):
         versions = library.list_versions(symbol)
         assert versions[0]['snapshots'] == []
         assert versions[1]['snapshots'] == ['previous']
-        assert_frame_equal(library.read(symbol, as_of='previous').data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of='previous').data, ts1)
 
         # ensure new snapshots are ordered after previous ones
         library.snapshot('new')
         versions = library.list_versions(symbol)
         assert versions[0]['snapshots'] == ['new']
         assert versions[0]['version'] == 2
-        assert_frame_equal(library.read(symbol, as_of='new').data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of='new').data, ts2)
 
         assert versions[1]['snapshots'] == ['previous']
         assert versions[1]['version'] == 1
-        assert_frame_equal(library.read(symbol, as_of='previous').data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of='previous').data, ts1)
 
         # ensure snapshot of previous version doesn't overwrite current version
         library.write(symbol, ts1, prune_previous_version=True)
@@ -657,14 +658,14 @@ def test_snapshot_with_versions(library, fw_pointers_cfg):
 
         assert versions[0]['snapshots'] == []
         assert versions[0]['version'] == 3
-        assert_frame_equal(library.read(symbol).data, ts1)
+        assert_frame_equal_(library.read(symbol).data, ts1)
 
         assert versions[1]['snapshots'] == ['new']
         assert versions[1]['version'] == 2
 
         assert versions[2]['snapshots'] == ['previous', 'another']
         assert versions[2]['version'] == 1
-        assert_frame_equal(library.read(symbol, as_of='another').data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of='another').data, ts1)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -691,13 +692,13 @@ def test_snapshot_delete(library, fw_pointers_cfg):
         with pytest.raises(NoDataFoundException):
             library.read(symbol, as_of='current')
         # But still accessible through the version
-        assert_frame_equal(library.read(symbol, as_of=1).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=2).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=1).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=2).data, ts2)
 
         # Snapshot again
         library.snapshot('current')
         library.write(symbol, ts1)
-        assert_frame_equal(library.read(symbol, as_of='current').data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of='current').data, ts2)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -711,14 +712,14 @@ def test_multiple_snapshots(library, fw_pointers_cfg):
         assert 'current' in library.list_snapshots()
         assert 'current2' in library.list_snapshots()
 
-        assert_frame_equal(library.read(symbol).data, ts2)
-        assert_frame_equal(library.read(symbol, as_of=1).data, ts1)
-        assert_frame_equal(library.read(symbol, as_of=2).data, ts2)
-        assert_frame_equal(library.read(symbol, as_of='current').data, ts1)
-        assert_frame_equal(library.read(symbol, as_of='current2').data, ts2)
+        assert_frame_equal_(library.read(symbol).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of=1).data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of=2).data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of='current').data, ts1)
+        assert_frame_equal_(library.read(symbol, as_of='current2').data, ts2)
 
         library.delete_snapshot('current')
-        assert_frame_equal(library.read(symbol, as_of='current2').data, ts2)
+        assert_frame_equal_(library.read(symbol, as_of='current2').data, ts2)
         library.delete_snapshot('current2')
         assert len(list(library.list_versions(symbol))) == 2
 
@@ -730,10 +731,10 @@ def test_delete_identical_snapshots(library):
     library.snapshot('current3')
 
     library.delete_snapshot('current3')
-    assert_frame_equal(library.read(symbol, as_of='current2').data, ts1)
+    assert_frame_equal_(library.read(symbol, as_of='current2').data, ts1)
     library.delete_snapshot('current1')
-    assert_frame_equal(library.read(symbol, as_of='current2').data, ts1)
-    assert_frame_equal(library.read(symbol).data, ts1)
+    assert_frame_equal_(library.read(symbol, as_of='current2').data, ts1)
+    assert_frame_equal_(library.read(symbol).data, ts1)
 
 
 def test_list_snapshots(library):
@@ -837,9 +838,9 @@ def test_prunes_multiple_versions_ts(library, fw_pointers_cfg):
         # Prunes all versions older than the most recent version that's older than 10 mins
         library.write(symbol, a, prune_previous_version=True)
         assert mongo_count(coll.versions) == 3
-        assert_frame_equal(library.read(symbol, as_of=3).data, a)
+        assert_frame_equal_(library.read(symbol, as_of=3).data, a)
         assert_frame_equal(library.read(symbol, as_of=4).data, c)
-        assert_frame_equal(library.read(symbol, as_of=5).data, a)
+        assert_frame_equal_(library.read(symbol, as_of=5).data, a)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -864,19 +865,19 @@ def test_prunes_doesnt_prune_snapshots_ts(library, fw_pointers_cfg):
         # Prunes all versions older than the most recent version that's older than 10 mins
         library.write(symbol, a, prune_previous_version=True)
         assert mongo_count(coll.versions) == 4
-        assert_frame_equal(library.read(symbol, as_of='snap').data, c)
-        assert_frame_equal(library.read(symbol, as_of=3).data, a)
-        assert_frame_equal(library.read(symbol, as_of=4).data, c)
-        assert_frame_equal(library.read(symbol, as_of=5).data, a)
+        assert_frame_equal_(library.read(symbol, as_of='snap').data, c)
+        assert_frame_equal_(library.read(symbol, as_of=3).data, a)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=5).data, a)
 
         # Remove the snapshot, the version should now be pruned
         library.delete_snapshot('snap')
         assert mongo_count(coll.versions) == 4
         library.write(symbol, c, prune_previous_version=True)
         assert mongo_count(coll.versions) == 4
-        assert_frame_equal(library.read(symbol, as_of=4).data, c)
-        assert_frame_equal(library.read(symbol, as_of=5).data, a)
-        assert_frame_equal(library.read(symbol, as_of=6).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=5).data, a)
+        assert_frame_equal_(library.read(symbol, as_of=6).data, c)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -906,9 +907,9 @@ def test_prunes_multiple_versions_fully_different_tss(library, fw_pointers_cfg):
 
         # Prunes all versions older than the most recent version that's older than 10 mins
         library.write(symbol, c, prune_previous_version=True)
-        assert_frame_equal(library.read(symbol, as_of=4).data, c)
-        assert_frame_equal(library.read(symbol, as_of=5).data, c)
-        assert_frame_equal(library.read(symbol, as_of=6).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=5).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=6).data, c)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -940,19 +941,19 @@ def test_prunes_doesnt_prune_snapshots_fully_different_tss(library, fw_pointers_
         # Prunes all versions older than the most recent version that's older than 10 mins
         library.write(symbol, c, prune_previous_version=True)
         assert mongo_count(coll.versions) == 5
-        assert_frame_equal(library.read(symbol, as_of='snap').data, c)
-        assert_frame_equal(library.read(symbol, as_of=4).data, c)
-        assert_frame_equal(library.read(symbol, as_of=5).data, c)
-        assert_frame_equal(library.read(symbol, as_of=6).data, c)
-        assert_frame_equal(library.read(symbol, as_of=7).data, c)
+        assert_frame_equal_(library.read(symbol, as_of='snap').data, c)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=5).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=6).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=7).data, c)
 
         library.delete_snapshot('snap')
         assert mongo_count(coll.versions) == 5
         library.write(symbol, c, prune_previous_version=True)
-        assert_frame_equal(library.read(symbol, as_of=4).data, c)
-        assert_frame_equal(library.read(symbol, as_of=5).data, c)
-        assert_frame_equal(library.read(symbol, as_of=6).data, c)
-        assert_frame_equal(library.read(symbol, as_of=7).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=4).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=5).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=6).data, c)
+        assert_frame_equal_(library.read(symbol, as_of=7).data, c)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -976,37 +977,37 @@ def test_prunes_previous_version_append_interaction(library, fw_pointers_cfg):
         with patch("bson.ObjectId", return_value=bson.ObjectId.from_datetime(now - dtd(minutes=130)),
                                     from_datetime=bson.ObjectId.from_datetime):
             library.write(symbol, ts, prune_previous_version=False)
-        assert_frame_equal(ts, library.read(symbol).data)
+        assert_frame_equal_(ts, library.read(symbol).data)
 
         with patch("bson.ObjectId", return_value=bson.ObjectId.from_datetime(now - dtd(minutes=129)),
                                     from_datetime=bson.ObjectId.from_datetime):
             library.write(symbol, ts2, prune_previous_version=False)
-        assert_frame_equal(ts, library.read(symbol, as_of=1).data)
-        assert_frame_equal(ts2, library.read(symbol).data)
+        assert_frame_equal_(ts, library.read(symbol, as_of=1).data)
+        assert_frame_equal_(ts2, library.read(symbol).data)
 
         with patch("bson.ObjectId", return_value=bson.ObjectId.from_datetime(now - dtd(minutes=128)),
                                     from_datetime=bson.ObjectId.from_datetime):
             library.write(symbol, ts3, prune_previous_version=False)
-        assert_frame_equal(ts, library.read(symbol, as_of=1).data)
-        assert_frame_equal(ts2, library.read(symbol, as_of=2).data)
-        assert_frame_equal(ts3, library.read(symbol).data)
+        assert_frame_equal_(ts, library.read(symbol, as_of=1).data)
+        assert_frame_equal_(ts2, library.read(symbol, as_of=2).data)
+        assert_frame_equal_(ts3, library.read(symbol).data)
 
         with patch("bson.ObjectId", return_value=bson.ObjectId.from_datetime(now - dtd(minutes=127)),
                                     from_datetime=bson.ObjectId.from_datetime):
             library.write(symbol, ts4, prune_previous_version=False)
-        assert_frame_equal(ts, library.read(symbol, as_of=1).data)
-        assert_frame_equal(ts2, library.read(symbol, as_of=2).data)
-        assert_frame_equal(ts3, library.read(symbol, as_of=3).data)
-        assert_frame_equal(ts4, library.read(symbol).data)
+        assert_frame_equal_(ts, library.read(symbol, as_of=1).data)
+        assert_frame_equal_(ts2, library.read(symbol, as_of=2).data)
+        assert_frame_equal_(ts3, library.read(symbol, as_of=3).data)
+        assert_frame_equal_(ts4, library.read(symbol).data)
 
         with patch("bson.ObjectId", return_value=bson.ObjectId.from_datetime(now - dtd(minutes=126)),
                                     from_datetime=bson.ObjectId.from_datetime):
             library.write(symbol, ts5, prune_previous_version=False)
-        assert_frame_equal(ts, library.read(symbol, as_of=1).data)
-        assert_frame_equal(ts2, library.read(symbol, as_of=2).data)
-        assert_frame_equal(ts3, library.read(symbol, as_of=3).data)
-        assert_frame_equal(ts4, library.read(symbol, as_of=4).data)
-        assert_frame_equal(ts5, library.read(symbol).data)
+        assert_frame_equal_(ts, library.read(symbol, as_of=1).data)
+        assert_frame_equal_(ts2, library.read(symbol, as_of=2).data)
+        assert_frame_equal_(ts3, library.read(symbol, as_of=3).data)
+        assert_frame_equal_(ts4, library.read(symbol, as_of=4).data)
+        assert_frame_equal_(ts5, library.read(symbol).data)
 
         with patch("bson.ObjectId", return_value=bson.ObjectId.from_datetime(now),
                                     from_datetime=bson.ObjectId.from_datetime):
@@ -1018,8 +1019,8 @@ def test_prunes_previous_version_append_interaction(library, fw_pointers_cfg):
             library.read(symbol, as_of=2)
         with pytest.raises(NoDataFoundException):
             library.read(symbol, as_of=3)
-        assert_frame_equal(ts5, library.read(symbol, as_of=5).data)
-        assert_frame_equal(ts6, library.read(symbol).data)
+        assert_frame_equal_(ts5, library.read(symbol, as_of=5).data)
+        assert_frame_equal_(ts6, library.read(symbol).data)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1044,9 +1045,10 @@ def test_snapshot_no_collscan(library):
 
     query_plan = list(profile_db.find({'command.aggregate': {'$exists': True}}))[-1]
 
-    assert query_plan.get('docsExamined') == 0
+    # TODO this can be 0 or 1 depending of query plan being IXSCAN or DEPENDS_SCAN
+    assert query_plan.get('docsExamined') <= 1
     assert query_plan.get('keysExamined') == 1
-    assert query_plan.get('planSummary').startswith('IXSCAN')
+    assert not query_plan.get('planSummary').startswith('COLLSCAN')
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1126,7 +1128,7 @@ def test_date_range_large(library, fw_pointers_cfg):
         df.columns = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
         library.write('test', df)
         r = library.read('test', date_range=DateRange(dt(2017, 1, 1), dt(2017, 1, 2)))
-        assert_frame_equal(df, r.data)
+        assert_frame_equal_(df, r.data)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1143,7 +1145,7 @@ def test_append_after_empty(library, fw_pointers_cfg):
         for i in range(len_df):
             library.append(symbol, df.iloc[i:i + 1])
         r = library.read(symbol)
-        assert_frame_equal(df, r.data)
+        assert_frame_equal_(df, r.data)
 
 
 def _rnd_df(nrows, ncols):
@@ -1171,10 +1173,10 @@ def test_write_metadata(library, fw_pointers_cfg):
             assert v_doc_2.get(FW_POINTERS_REFS_KEY) == v_doc_3.get(FW_POINTERS_REFS_KEY)
 
             v = library.read(symbol)
-            assert_frame_equal(v.data, mydf_b)
+            assert_frame_equal_(v.data, mydf_b, check_freq=False)
             assert v.metadata == {'field_b': 1}
             assert library._read_metadata(symbol).get('version') == 3
-            assert_frame_equal(library.read(symbol, as_of=1).data, mydf_a)
+            assert_frame_equal_(library.read(symbol, as_of=1).data, mydf_a, check_freq=False)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1192,10 +1194,10 @@ def test_write_metadata_followed_by_append(library, fw_pointers_cfg):
             library._prune_previous_versions(symbol, 0)
 
             v = library.read(symbol)
-            assert_frame_equal(v.data, mydf_a.append(mydf_b))
+            assert_frame_equal_(v.data, mydf_a.append(mydf_b), check_freq=False)
             assert v.metadata == {'field_c': 1}
             assert library._read_metadata(symbol).get('version') == 3
-            assert_frame_equal(library.read(symbol, as_of=1).data, mydf_a)
+            assert_frame_equal_(library.read(symbol, as_of=1).data, mydf_a, check_freq=False)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1220,7 +1222,7 @@ def test_write_metadata_after_append(library, fw_pointers_cfg):
             library.append(symbol, data=mydf_b, metadata={'field_a': 2})  # creates version 2
             library.write_metadata(symbol, metadata={'field_b': 1})  # creates version 3
             v = library.read(symbol)
-            assert_frame_equal(v.data, mydf_a.append(mydf_b))
+            assert_frame_equal_(v.data, mydf_a.append(mydf_b), check_freq=False)
             assert v.metadata == {'field_b': 1}
             assert library._read_metadata(symbol).get('version') == 3
 
@@ -1243,14 +1245,14 @@ def test_write_metadata_purge_previous_versions(library, fw_pointers_cfg):
 
                 # Assert the data
                 v = library.read(symbol)
-                assert_frame_equal(v.data, mydf_b)
+                assert_frame_equal_(v.data, mydf_b, check_freq=False)
                 assert v.metadata == {'field_b': 1}
 
                 # Check if after snapshot and deleting the symbol, the data/metadata survive
                 library.snapshot('SNAP_1')
                 library.delete(symbol)
                 v = library.read(symbol, as_of='SNAP_1')
-                assert_frame_equal(v.data, mydf_b)
+                assert_frame_equal_(v.data, mydf_b, check_freq=False)
                 assert library._read_metadata(symbol, as_of='SNAP_1').get('version') == 3
                 assert v.metadata == {'field_b': 1}
 
@@ -1271,7 +1273,7 @@ def test_write_metadata_delete_symbol(library, fw_pointers_cfg):
                 library.read(symbol)
 
             library.write(symbol, data=mydf_b, metadata={'field_a': 1})  # creates version 1
-            assert_frame_equal(library.read(symbol).data, mydf_b)
+            assert_frame_equal_(library.read(symbol).data, mydf_b, check_freq=False)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1290,15 +1292,15 @@ def test_write_metadata_snapshots(library, fw_pointers_cfg):
             library._prune_previous_versions(symbol, keep_mins=0)
 
             v = library.read(symbol)
-            assert_frame_equal(v.data, mydf_b)
+            assert_frame_equal_(v.data, mydf_b, check_freq=False)
             assert v.metadata == {'field_c': 1}
 
             v = library.read(symbol, as_of='SNAP_1')
-            assert_frame_equal(v.data, mydf_a)
+            assert_frame_equal_(v.data, mydf_a, check_freq=False)
             assert v.metadata == {'field_a': 1}
 
             v = library.read(symbol, as_of='SNAP_2')
-            assert_frame_equal(v.data, mydf_a)
+            assert_frame_equal_(v.data, mydf_a, check_freq=False)
             assert v.metadata == {'field_b': 1}
 
 
@@ -1313,7 +1315,7 @@ def test_restore_version(library, fw_pointers_cfg):
             library.write(symbol, data=mydf_b, metadata={'field_a': 2})  # creates version 2
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_b)
+            assert_frame_equal_(item.data, mydf_b, check_freq=False)
             assert item.metadata == {'field_a': 2}
             assert library._read_metadata(symbol).get('version') == 2
 
@@ -1322,7 +1324,7 @@ def test_restore_version(library, fw_pointers_cfg):
             assert restore_item.metadata == {'field_a': 1}
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_a)
+            assert_frame_equal_(item.data, mydf_a, check_freq=False)
             assert item.metadata == {'field_a': 1}
             assert library._read_metadata(symbol).get('version') == 3
 
@@ -1349,7 +1351,7 @@ def test_restore_version_followed_by_append(library, fw_pointers_cfg):
             time.sleep(2)
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_a.append(mydf_c))
+            assert_frame_equal_(item.data, mydf_a.append(mydf_c), check_freq=False)
             assert item.metadata == {'field_c': 3}
             assert library._read_metadata(symbol).get('version') == 4
 
@@ -1375,7 +1377,7 @@ def test_restore_version_purging_previous_versions(library, fw_pointers_cfg):
             # library._delete_version(symbol, 1)  # delete the original version to test further the robustness/dependency
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_a)
+            assert_frame_equal_(item.data, mydf_a, False)
             assert item.metadata == {'field_a': 1}
             assert library._read_metadata(symbol).get('version') == 3
 
@@ -1392,7 +1394,7 @@ def test_restore_version_non_existent_version(library, fw_pointers_cfg):
                 library.restore_version(symbol, as_of=3)
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_a)
+            assert_frame_equal_(item.data, mydf_a, check_freq=False)
             assert item.metadata == {'field_a': 1}
             assert item.version == 1
 
@@ -1413,7 +1415,7 @@ def test_restore_version_which_updated_only_metadata(library, fw_pointers_cfg):
             assert restore_item.metadata == {'field_b': 1}
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_a)
+            assert_frame_equal_(item.data, mydf_a, check_freq=False)
             assert item.metadata == {'field_b': 1}
             assert item.version == 4
 
@@ -1436,7 +1438,7 @@ def test_restore_version_then_snapshot(library, fw_pointers_cfg):
             library.write(symbol, data=mydf_b)  # creates version 3
 
             item = library.read(symbol, as_of='SNAP_1')
-            assert_frame_equal(item.data, mydf_a)
+            assert_frame_equal_(item.data, mydf_a, check_freq=False)
             assert item.metadata == {'field_a': 1}
             assert item.version == 3
 
@@ -1456,7 +1458,7 @@ def test_restore_version_latest_snapshot_noop(library, fw_pointers_cfg):
             assert restore_item.version == 2
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_a)
+            assert_frame_equal_(item.data, mydf_a, check_freq=False)
             assert item.metadata == {'field_b': 1}
             assert item.version == 2
 
@@ -1475,7 +1477,7 @@ def test_restore_version_latest_version_noop(library, fw_pointers_cfg):
             assert restore_item.version == 2
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf_a)
+            assert_frame_equal_(item.data, mydf_a, check_freq=False)
             assert item.metadata == {'field_b': 1}
             assert item.version == 2
 
@@ -1498,7 +1500,7 @@ def test_restore_version_snap_delete_symbol_restore(library, fw_pointers_cfg):
             assert restored_item.version == 5
 
             item = library.read(symbol)
-            assert_frame_equal(item.data, mydf[:15])
+            assert_frame_equal_(item.data, mydf[:15], check_freq=False)
             assert item.metadata == {'field_a': 1}
             assert item.version == 5
 
@@ -1640,7 +1642,7 @@ def test_write_non_serializable_throws(arctic):
 
         # Check that saving a regular dataframe succeeds with this option set
         library.write('ns2', ts1)
-        assert_frame_equal(ts1, library.read('ns2').data)
+        assert_frame_equal_(ts1, library.read('ns2').data, check_freq=False)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1651,7 +1653,7 @@ def test_write_non_serializable_pickling_default(arctic, fw_pointers_cfg):
         library = arctic[lib_name]
         df = pd.DataFrame({'a': [dict(a=1)]})
         library.write('ns3', df)
-        assert_frame_equal(df, library.read('ns3').data)
+        assert_frame_equal_(df, library.read('ns3').data, check_freq=False)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1703,7 +1705,7 @@ def test_write_df_with_objects_in_index(library):
     df = _mixed_test_data()['multiindex_with_object'][0]
     library.write(symbol='symX', data=df)
     read_data = library.read(symbol='symX').data
-    assert_frame_equal(df, read_data)
+    assert_frame_equal_(df, read_data)
 
 
 def test_write_series_with_objects_in_index(library):
@@ -1730,7 +1732,7 @@ def test_can_write_tz_aware_data_df(library, fw_pointers_cfg):
         # Arctic converts by default the data to UTC, convert back
         read_data.colB = read_data.colB.dt.tz_localize('UTC').dt.tz_convert(read_data.index.tzinfo)
         assert library._versions.find_one({'symbol': 'symTz'})['type'] == PandasDataFrameStore.TYPE
-        assert_frame_equal(mydf, read_data)
+        assert_frame_equal_(mydf, read_data, check_freq=False)
 
 
 @pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
@@ -1809,7 +1811,7 @@ def test_fwpointers_mixed_scenarios(library, write_cfg, read_cfg, append_cfg, re
 
         # The read
         with FwPointersCtx(read_cfg):
-            assert_frame_equal(to_write, library.read(symbol=symbol).data)
+            assert_frame_equal_(to_write, library.read(symbol=symbol).data)
 
         # The append
         with FwPointersCtx(append_cfg):
@@ -1819,7 +1821,7 @@ def test_fwpointers_mixed_scenarios(library, write_cfg, read_cfg, append_cfg, re
 
         # The final read
         with FwPointersCtx(reread_cfg):
-            assert_frame_equal(mydf, library.read(symbol=symbol).data)
+            assert_frame_equal_(mydf, library.read(symbol=symbol).data)
 
     assert outer['raised']
 
@@ -1833,7 +1835,7 @@ def test_fwpointers_writemetadata_enabled_disabled(library):
 
     with FwPointersCtx(FwPointersCfg.ENABLED):
         library.write(symbol=symbol, data=to_write_a)
-        assert_frame_equal(to_write_a, library.read(symbol=symbol).data)
+        assert_frame_equal_(to_write_a, library.read(symbol=symbol).data)
 
     with FwPointersCtx(FwPointersCfg.DISABLED):
         library.write_metadata(symbol=symbol, metadata={'key_a': 100})
@@ -1842,16 +1844,16 @@ def test_fwpointers_writemetadata_enabled_disabled(library):
     with FwPointersCtx(FwPointersCfg.ENABLED):
         vitem = library.read(symbol)
         assert vitem.metadata == {'key_a': 100}
-        assert_frame_equal(to_write_a, vitem.data)
+        assert_frame_equal_(to_write_a, vitem.data)
 
     with FwPointersCtx(FwPointersCfg.DISABLED):
         vitem = library.read(symbol)
         assert vitem.metadata == {'key_a': 100}
-        assert_frame_equal(to_write_a, vitem.data)
+        assert_frame_equal_(to_write_a, vitem.data)
 
     with FwPointersCtx(FwPointersCfg.ENABLED):
         library.append(symbol=symbol, data=to_write_b, prune_previous_version=False)
-        assert_frame_equal(mydf, library.read(symbol=symbol).data)
+        assert_frame_equal_(mydf, library.read(symbol=symbol).data)
 
     last_v = library._versions.find_one({'symbol': symbol}, sort=[("version", pymongo.DESCENDING)])
     assert len(last_v.get(FW_POINTERS_REFS_KEY)) == 2
@@ -1859,12 +1861,12 @@ def test_fwpointers_writemetadata_enabled_disabled(library):
     with FwPointersCtx(FwPointersCfg.ENABLED):
         vitem = library.read(symbol, as_of=2)
         assert vitem.metadata == {'key_a': 100}
-        assert_frame_equal(to_write_a, vitem.data)
+        assert_frame_equal_(to_write_a, vitem.data)
 
     with FwPointersCtx(FwPointersCfg.DISABLED):
         vitem = library.read(symbol, as_of=2)
         assert vitem.metadata == {'key_a': 100}
-        assert_frame_equal(to_write_a, vitem.data)
+        assert_frame_equal_(to_write_a, vitem.data)
 
 
 def test_fwpointer_enabled_write_delete_keep_version_append(library):
@@ -1878,7 +1880,7 @@ def test_fwpointer_enabled_write_delete_keep_version_append(library):
         library.write(symbol=symbol, data=to_write_a)
         library.append(symbol=symbol, data=to_write_b)
         library.snapshot('snapA')
-        assert_frame_equal(mydf, library.read(symbol=symbol).data)
+        assert_frame_equal_(mydf, library.read(symbol=symbol).data)
 
     with FwPointersCtx(FwPointersCfg.DISABLED):
         library.delete(symbol)
@@ -1886,7 +1888,7 @@ def test_fwpointer_enabled_write_delete_keep_version_append(library):
 
     with FwPointersCtx(FwPointersCfg.ENABLED):
         library.write(symbol=symbol, data=to_write_a)
-        assert_frame_equal(to_write_a, library.read(symbol=symbol).data)
+        assert_frame_equal_(to_write_a, library.read(symbol=symbol).data)
 
 
 def test_version_arctic_version(arctic):
@@ -1920,14 +1922,14 @@ def test_prune_mixed_fwpointer_configs(library):
     with FwPointersCtx(FwPointersCfg.ENABLED):
         library.append(symbol, to_write_c, prune_previous_version=False)
 
-    assert_frame_equal(to_write_a, library.read(symbol, as_of=1).data)
-    assert_frame_equal(pd.concat((to_write_a, to_write_b)), library.read(symbol, as_of=2).data)
-    assert_frame_equal(mydf, library.read(symbol).data)
+    assert_frame_equal_(to_write_a, library.read(symbol, as_of=1).data)
+    assert_frame_equal_(pd.concat((to_write_a, to_write_b)), library.read(symbol, as_of=2).data)
+    assert_frame_equal_(mydf, library.read(symbol).data)
 
     library._prune_previous_versions(symbol, keep_mins=0)
     assert mongo_count(library._versions, {'symbol': symbol}) == 1
 
-    assert_frame_equal(mydf, library.read(symbol).data)
+    assert_frame_equal_(mydf, library.read(symbol).data)
 
 
 @pytest.mark.parametrize('first_write_cfg, second_write_cfg', [
@@ -1951,10 +1953,10 @@ def test_prune_crossref_fwpointer_configs(library, first_write_cfg, second_write
         library.write(symbol, to_write_a_b)
     with FwPointersCtx(second_write_cfg):
         library.write(symbol, to_write_b_c, prune_previous_version=False)
-    assert_frame_equal(to_write_b_c, library.read(symbol).data)
+    assert_frame_equal_(to_write_b_c, library.read(symbol).data)
     library._prune_previous_versions(symbol, keep_mins=0)
     assert mongo_count(library._versions, {'symbol': symbol}) == 1
-    assert_frame_equal(to_write_b_c, library.read(symbol).data)
+    assert_frame_equal_(to_write_b_c, library.read(symbol).data)
 
     library.delete(symbol)
     assert mongo_count(library._versions, {'symbol': symbol}) == 0

--- a/tests/integration/tickstore/test_ts_write.py
+++ b/tests/integration/tickstore/test_ts_write.py
@@ -3,6 +3,7 @@ from datetime import datetime as dt
 import pytest
 import pytz
 from pandas.util.testing import assert_frame_equal
+from tests.util import assert_frame_equal_
 
 from arctic.date import mktz, DateRange
 from arctic.exceptions import OverlappingDataException
@@ -73,7 +74,7 @@ def test_ts_write_pandas(tickstore_lib):
     tickstore_lib.write('SYM', data)
 
     read = tickstore_lib.read('SYM', columns=None)
-    assert_frame_equal(read, data, check_names=False)
+    assert_frame_equal_(read, data, check_names=False)
 
 
 def test_ts_write_named_col(tickstore_lib):

--- a/tests/unit/serialization/test_numpy_arrays.py
+++ b/tests/unit/serialization/test_numpy_arrays.py
@@ -4,6 +4,7 @@ import pytest
 from pandas.util.testing import assert_frame_equal
 
 from arctic.serialization.numpy_arrays import FrameConverter, FrametoArraySerializer
+from tests.util import assert_frame_equal_
 
 
 def test_frame_converter():
@@ -11,14 +12,14 @@ def test_frame_converter():
     df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
                       columns=list('ABCD'))
 
-    assert_frame_equal(f.objify(f.docify(df)), df)
+    assert_frame_equal_(f.objify(f.docify(df)), df)
 
 
 def test_with_strings():
     f = FrameConverter()
     df = pd.DataFrame(data={'one': ['a', 'b', 'c']})
 
-    assert_frame_equal(f.objify(f.docify(df)), df)
+    assert_frame_equal_(f.objify(f.docify(df)), df)
 
 
 def test_frame_converter_with_all_valid_column_subset():
@@ -26,7 +27,7 @@ def test_frame_converter_with_all_valid_column_subset():
     df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
                       columns=list('ABCD'))
 
-    assert_frame_equal(f.objify(f.docify(df), columns=['A', 'B']), df[['A', 'B']])
+    assert_frame_equal_(f.objify(f.docify(df), columns=['A', 'B']), df[['A', 'B']])
 
 
 def test_frame_converter_with_some_invalid_column_subset():
@@ -34,7 +35,7 @@ def test_frame_converter_with_some_invalid_column_subset():
     df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
                       columns=list('ABCD'))
     expected = pd.DataFrame({'A': df['A'], 'N': np.nan})
-    assert_frame_equal(f.objify(f.docify(df), columns=['A', 'N']), expected[['A', 'N']])
+    assert_frame_equal_(f.objify(f.docify(df), columns=['A', 'N']), expected[['A', 'N']])
 
 
 def test_frame_converter_with_no_valid_column_subset():
@@ -64,7 +65,7 @@ def test_without_index():
                       columns=list('ABCD'))
     n = FrametoArraySerializer()
     a = n.serialize(df)
-    assert_frame_equal(df, n.deserialize(a))
+    assert_frame_equal_(df, n.deserialize(a))
 
 
 def test_with_index():
@@ -73,7 +74,7 @@ def test_with_index():
     df = df.set_index(['A'])
     n = FrametoArraySerializer()
     a = n.serialize(df)
-    assert_frame_equal(df, n.deserialize(a))
+    assert_frame_equal_(df, n.deserialize(a))
 
 
 def test_invalid_column_subset_with_index():
@@ -116,7 +117,7 @@ def test_with_nans():
     df['A'] = np.NaN
     n = FrametoArraySerializer()
     a = n.serialize(df)
-    assert_frame_equal(df, n.deserialize(a))
+    assert_frame_equal_(df, n.deserialize(a))
 
 
 def test_empty_dataframe():
@@ -130,7 +131,7 @@ def test_empty_columns():
     df = pd.DataFrame(data={'A': [], 'B': [], 'C': []})
     n = FrametoArraySerializer()
     a = n.serialize(df)
-    assert_frame_equal(df, n.deserialize(a))
+    assert_frame_equal_(df, n.deserialize(a))
 
 
 def test_string_cols_with_nans():

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,7 +1,8 @@
 from mock import MagicMock, ANY, patch
 
-from arctic._util import are_equals, enable_sharding, mongo_count, _use_new_count_api
+from arctic._util import are_equals, enable_sharding, mongo_count
 from arctic.arctic import Arctic
+import arctic._util
 
 
 def test_are_equals_not_df():
@@ -16,21 +17,25 @@ def test_enable_sharding_hashed():
     m._conn.admin.command.assert_called_with('shardCollection', ANY, key={'symbol': 'hashed'})
 
 
-def test_mongo_count_old_pymongo():
-    _use_new_count_api = None
+def test_mongo_count_old_pymongo(monkeypatch):
+    monkeypatch.setattr(arctic._util, '_use_new_count_api', None)
     with patch('pymongo.version', '3.6.0'):
         coll = MagicMock()
         mongo_count(coll, filter="_id:1")
         mongo_count(coll, filter={})
         mongo_count(coll)
+        assert coll.estimated_document_count.call_count == 0
+        assert coll.count_documents.call_count == 0
         assert coll.count.call_count == 3
 
-def test_mongo_count_new_pymongo():
-    _use_new_count_api = None
+
+def test_mongo_count_new_pymongo(monkeypatch):
+    monkeypatch.setattr(arctic._util, '_use_new_count_api', None)
     with patch('pymongo.version', '3.11.0'):
         coll2 = MagicMock()
         mongo_count(coll2, filter="_id:1")
         mongo_count(coll2, filter={})
         mongo_count(coll2)
         assert coll2.estimated_document_count.call_count == 2
-        coll2.count_documents.assert_called_once()
+        assert coll2.count_documents.call_count == 1
+        assert coll2.count.call_count == 0

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,6 @@
-from mock import MagicMock, ANY
+from mock import MagicMock, ANY, patch
 
-from arctic._util import are_equals, enable_sharding
+from arctic._util import are_equals, enable_sharding, mongo_count
 from arctic.arctic import Arctic
 
 
@@ -14,3 +14,21 @@ def test_enable_sharding_hashed():
     m = MagicMock(Arctic, autospec=True)
     enable_sharding(m, "test", hashed=True)
     m._conn.admin.command.assert_called_with('shardCollection', ANY, key={'symbol': 'hashed'})
+
+
+def test_mongo_count_old_pymongo():
+    with patch('pymongo.version', '3.6.0'):
+        coll = MagicMock()
+        mongo_count(coll, filter="_id:1")
+        mongo_count(coll, filter={})
+        mongo_count(coll)
+        assert coll.count.call_count == 3
+
+def test_mongo_count_new_pymongo():
+    with patch('pymongo.version', '3.11.0'):
+        coll2 = MagicMock()
+        mongo_count(coll2, filter="_id:1")
+        mongo_count(coll2, filter={})
+        mongo_count(coll2)
+        assert coll2.estimated_document_count.call_count == 2
+        coll2.count_documents.assert_called_once()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,6 @@
 from mock import MagicMock, ANY, patch
 
-from arctic._util import are_equals, enable_sharding, mongo_count
+from arctic._util import are_equals, enable_sharding, mongo_count, _use_new_count_api
 from arctic.arctic import Arctic
 
 
@@ -17,6 +17,7 @@ def test_enable_sharding_hashed():
 
 
 def test_mongo_count_old_pymongo():
+    _use_new_count_api = None
     with patch('pymongo.version', '3.6.0'):
         coll = MagicMock()
         mongo_count(coll, filter="_id:1")
@@ -25,6 +26,7 @@ def test_mongo_count_old_pymongo():
         assert coll.count.call_count == 3
 
 def test_mongo_count_new_pymongo():
+    _use_new_count_api = None
     with patch('pymongo.version', '3.11.0'):
         coll2 = MagicMock()
         mongo_count(coll2, filter="_id:1")

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,6 +11,18 @@ import dateutil
 import numpy as np
 import pandas
 from dateutil.rrule import rrule, DAILY
+from pandas.util.testing import assert_frame_equal
+
+
+def assert_frame_equal_(df1, df2, check_freq=True, check_names=True):
+    if pandas.__version__ > '1.0.3':
+        # had to add check_freq because pandas 1.1.5 has different freq metadata behaviour
+        assert_frame_equal(df1.sort_index(axis=1), df2.sort_index(axis=1), check_names=check_names, check_freq=check_freq)
+    else:
+        # pandas 1.0.3
+        assert_frame_equal(df1.sort_index(axis=1), df2.sort_index(axis=1), check_names=check_names)
+    #else: # 0.22.0 python 2.7
+        #assert_frame_equal(df1, df2, check_names=check_names)
 
 
 def dt_or_str_parser(string):


### PR DESCRIPTION
I rebased this branch to pull in the fixed tests.  The actual issue this PR fixes in  arctic._util.mongo_count() in _util.py which used to run very slowly with filter == {}, and pymongo 3.11.0.   