### PR TITLE
Import Panel in the method where it is needed to prevent errors

### DIFF
--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -4,10 +4,6 @@ import logging
 import numpy as np
 from bson.binary import Binary
 from pandas import DataFrame, Series
-try:
-    from pandas import Panel
-except ImportError:
-    pass
 
 from arctic._util import NP_OBJECT_DTYPE
 from arctic.serialization.numpy_records import SeriesSerializer, DataFrameSerializer
@@ -217,7 +213,11 @@ class PandasPanelStore(PandasDataFrameStore):
 
     @staticmethod
     def can_write_type(data):
-        return isinstance(data, Panel)
+        try:
+            from pandas import Panel
+            return isinstance(data, Panel)
+        except ImportError:
+            return False
 
     def can_write(self, version, symbol, data):
         if self.can_write_type(data):


### PR DESCRIPTION
Importing `Panel` in the method where it is explicitly used prevents errors in case of `ImportError`.