### PR TITLE
Revert serialization optimization

### DIFF
--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -7,7 +7,7 @@ from bson import Binary, SON
 
 from .._compression import compress, decompress, compress_array
 from ._serializer import Serializer
-from collections import defaultdict
+
 try:
     from pandas.api.types import infer_dtype
 except ImportError:
@@ -139,35 +139,31 @@ class FrameConverter(object):
 
         return doc
 
-    def objify(self, doc, columns=None, as_df=True):
+    def objify(self, doc, columns=None):
         """
         Decode a Pymongo SON object into an Pandas DataFrame
         """
         cols = columns or doc[METADATA][COLUMNS]
         data = {}
-        valid_columns = doc[METADATA][LENGTHS]
-        missing_columns = set(cols).difference(valid_columns)
-        for col in valid_columns:
-            d = decompress(doc[DATA][doc[METADATA][LENGTHS][col][0]: doc[METADATA][LENGTHS][col][1] + 1])
-            # d is ready-only but that's not an issue since DataFrame will copy the data anyway.
-            d = np.frombuffer(d, doc[METADATA][DTYPE][col])
 
-            if MASK in doc[METADATA] and col in doc[METADATA][MASK]:
-                mask_data = decompress(doc[METADATA][MASK][col])
-                mask = np.frombuffer(mask_data, 'bool')
-                d = ma.masked_array(d, mask)
+        for col in cols:
+            # if there is missing data in a chunk, we can default to NaN
+            # and pandas will autofill the missing values to the correct length
+            if col not in doc[METADATA][LENGTHS]:
+                d = np.array(np.nan)
+            else:
+                d = decompress(doc[DATA][doc[METADATA][LENGTHS][col][0]: doc[METADATA][LENGTHS][col][1] + 1])
+                # d is ready-only but that's not an issue since DataFrame will copy the data anyway.
+                d = np.frombuffer(d, doc[METADATA][DTYPE][col])
+
+                if MASK in doc[METADATA] and col in doc[METADATA][MASK]:
+                    mask_data = decompress(doc[METADATA][MASK][col])
+                    mask = np.frombuffer(mask_data, 'bool')
+                    d = ma.masked_array(d, mask)
             data[col] = d
 
-        for col in missing_columns:
-            # if there is missing data in a chunk, we can default to NaN and
-            empty = np.empty(len(d))
-            empty[:] = np.nan
-            data[col] = empty
-
-        if as_df:
-            return pd.DataFrame(data)
-
-        return data
+        # Copy into
+        return pd.DataFrame(data, columns=cols, copy=True)[cols]
 
 
 class FrametoArraySerializer(Serializer):
@@ -226,24 +222,12 @@ class FrametoArraySerializer(Serializer):
                 raise Exception("Duplicate columns specified, cannot de-serialize")
 
         if not isinstance(data, list):
-            data = [data]
-
-        df = defaultdict(list)
-
-        for d in data:
-            for k, v in self.converter.objify(d, columns, as_df=False).items():
-                df[k].append(v)
-
-        idx_cols = meta[INDEX] if index else []
-        if len(idx_cols) > 1:
-            idx = pd.MultiIndex.from_arrays([np.concatenate(df[k]) for k in idx_cols], names=idx_cols)
-        elif len(idx_cols) == 1:
-            idx = pd.Index(np.concatenate(df[idx_cols[0]]), name=idx_cols[0])
+            df = self.converter.objify(data, columns)
         else:
-            idx = None
+            df = pd.concat([self.converter.objify(d, columns) for d in data], ignore_index=not index)
 
-        df = pd.DataFrame({k: np.concatenate(v) for k, v in df.items() if k not in idx_cols}, index=idx)
-
+        if index:
+            df = df.set_index(meta[INDEX])
         if meta[TYPE] == 'series':
             return df[df.columns[0]]
         return df

--- a/tests/unit/serialization/test_numpy_arrays.py
+++ b/tests/unit/serialization/test_numpy_arrays.py
@@ -22,29 +22,6 @@ def test_with_strings():
     assert_frame_equal_(f.objify(f.docify(df)), df)
 
 
-def test_frame_converter_with_all_valid_column_subset():
-    f = FrameConverter()
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
-                      columns=list('ABCD'))
-
-    assert_frame_equal_(f.objify(f.docify(df), columns=['A', 'B']), df[['A', 'B']])
-
-
-def test_frame_converter_with_some_invalid_column_subset():
-    f = FrameConverter()
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
-                      columns=list('ABCD'))
-    expected = pd.DataFrame({'A': df['A'], 'N': np.nan})
-    assert_frame_equal_(f.objify(f.docify(df), columns=['A', 'N']), expected[['A', 'N']])
-
-
-def test_frame_converter_with_no_valid_column_subset():
-    f = FrameConverter()
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
-                      columns=list('ABCD'))
-    assert f.objify(f.docify(df), columns=['N']).empty
-
-
 def test_with_objects_raises():
     class Example(object):
         def __init__(self, data):
@@ -75,40 +52,6 @@ def test_with_index():
     n = FrametoArraySerializer()
     a = n.serialize(df)
     assert_frame_equal_(df, n.deserialize(a))
-
-
-def test_invalid_column_subset_with_index():
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
-                      columns=list('ABCD'))
-    df = df.set_index(['A'])
-    n = FrametoArraySerializer()
-    a = n.serialize(df)
-    expected = pd.DataFrame({'N': np.nan}, index=df.index)
-    assert_frame_equal(expected, n.deserialize(a, columns=['N']))
-
-
-@pytest.mark.parametrize('index', [True, False])
-@pytest.mark.parametrize('columns', [None, ['B', 'D'], ['D', 'B']])
-def test_multiple_data_input_different_columns(columns, index):
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
-                      columns=list('ABCD'))
-    if index:
-        df = df.set_index(['A'])
-    n = FrametoArraySerializer()
-    a = n.serialize(df[['B']])
-    b = n.serialize(df[['D']])
-    expected = df[['B']].append(df[['D']], ignore_index=not index)
-    assert_frame_equal(expected, n.deserialize([a, b], columns=columns))
-
-
-@pytest.mark.parametrize('column', [['B'], ['D']])
-def test_multiple_data_input_with_no_index_and_invalid_column(column):
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
-                      columns=list('ABCD'))
-    n = FrametoArraySerializer()
-    a = n.serialize(df[['B']])
-    b = n.serialize(df[['D']])
-    assert_frame_equal(df[column], n.deserialize([a, b], columns=column))
 
 
 def test_with_nans():


### PR DESCRIPTION
Reverting the following commits:
- ddb31d0
- 8118025

2 bugs need to be addressed before this change can go in:
- missing data in string columns need to be converted to NaNs
- In the case of multiple chunks being passed into the Serializer, if a column is present in one chunk and not another AND the missing column is of datetime type, it needs to fill with NaT's.

