### PR TITLE
release/1.80.2 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       PYTHON_VERSION: "2_7"
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/2_7
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/2_7
-      VERSION: 1.80.1
+      VERSION: 1.80.2
       #PANDOC_RELEASES_URL: https://github.com/jgm/pandoc/releases
       #YARN_STATIC_DIR: notebooker/web/static/
       IMAGE_NAME: mangroup/arctic
@@ -115,7 +115,7 @@ jobs:
       PYTHON_VERSION: "3_6"
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/3_6
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/3_6
-      VERSION: 1.80.1
+      VERSION: 1.80.2
       #PANDOC_RELEASES_URL: https://github.com/jgm/pandoc/releases
       #YARN_STATIC_DIR: notebooker/web/static/
       IMAGE_NAME: mangroup/arctic
@@ -128,7 +128,7 @@ jobs:
       PYTHON_VERSION: "3_7"
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts/3_7
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results/3_7
-      VERSION: 1.80.1
+      VERSION: 1.80.2
       #PANDOC_RELEASES_URL: https://github.com/jgm/pandoc/releases
       #YARN_STATIC_DIR: notebooker/web/static/
       IMAGE_NAME: mangroup/arctic

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.80.2 (2022-01-10)
+  * Bugfix: #932 revert serialization-optimization (#909, #910)
+
 ### 1.80.1 (2021-12-09)
   * Bugfix: #855 use IXSCAN for list\_symbols which speeds up snapshotting (actually #856)
   * Bugfix: #926 avoid pathologically slow count_documents() call with pymongo > 3.6.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Arctic can query millions of rows per second per client, achieves ~10x compressi
 ~10x compression on disk, and scales to hundreds of millions of rows per second per
 [MongoDB](https://www.mongodb.org/) instance.
 
-Arctic has been under active development at [Man AHL](http://www.ahl.com/) since 2012.
+Arctic has been under active development at [Man AHL](https://www.man.com/ahl) since 2012.
 
 ## Quickstart
 
@@ -114,7 +114,7 @@ Arctic storage implementations are **pluggable**.  VersionStore is the default.
 
 Arctic currently works with:
 
- * Python 3.5, 3.6
+ * Python 3.6, 3.7
  * pymongo 3.60 thru 3.11.0
  * Pandas 0.22.0 thru 1.0.3
  * MongoDB >= 2.4.x
@@ -127,7 +127,7 @@ Operating Systems:
 
 ## Acknowledgements
 
-Arctic has been under active development at [Man AHL](http://www.ahl.com/) since 2012.
+Arctic has been under active development at [Man AHL](https://www.man.com/ahl) since 2012.
 
 It wouldn't be possible without the work of the AHL Data Engineering Team including:
 

--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -7,7 +7,6 @@ from bson import Binary, SON
 
 from .._compression import compress, decompress, compress_array
 from ._serializer import Serializer
-from collections import defaultdict
 
 try:
     from pandas.api.types import infer_dtype

--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -7,6 +7,7 @@ from bson import Binary, SON
 
 from .._compression import compress, decompress, compress_array
 from ._serializer import Serializer
+from collections import defaultdict
 
 try:
     from pandas.api.types import infer_dtype

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
                       "pytest-cov",
                       "pytest",
                       "pytz",
-                      "tomli==1.2.2; python_version=='3.6'",
+                      "tomli==1.2.3; python_version=='3.6'",
                       "tzlocal",
                       "lz4",
                      ],

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
                       "mockextras",
                       "pandas<=1.0.3",
                       "numpy<=1.18.4",
-                      "pymongo>=3.6.0, <= 3.11.0"
+                      "pymongo>=3.6.0, <= 3.11.0",
                       #"pytest-server-fixtures", # must be manual
                       "pytest-cov",
                       "pytest",

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
                       "pytest-cov",
                       "pytest",
                       "pytz",
-                      "tomli==1.2.2",
                       "tzlocal",
                       "lz4",
                      ],
@@ -99,6 +98,7 @@ setup(
                    "pytest-server-fixtures",
                    "pytest-timeout",
                    "pytest-xdist<=1.26.1",
+                   "tomli==1.2.2; python_version=='3.6'",
                    "lz4"
                   ],
     entry_points={'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
                       "pytest-cov",
                       "pytest",
                       "pytz",
+                      "tomli==1.2.2",
                       "tzlocal",
                       "lz4",
                      ],

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
                       "pytest-cov",
                       "pytest",
                       "pytz",
+                      "tomli==1.2.2; python_version=='3.6'",
                       "tzlocal",
                       "lz4",
                      ],
@@ -98,7 +99,6 @@ setup(
                    "pytest-server-fixtures",
                    "pytest-timeout",
                    "pytest-xdist<=1.26.1",
-                   "tomli==1.2.2; python_version=='3.6'",
                    "lz4"
                   ],
     entry_points={'console_scripts': [


### PR DESCRIPTION
Bugfix: #932 revert serialization-optimization (#909, #910) (chunkStore fixes removed that broke 1.80.1)
pinned tomli==1.2.3; python_version=='3.6'