### PR TITLE
Handle zero rows_per_chunk for ndarray_store

### DIFF
--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -636,7 +636,10 @@ class NdarrayStore(object):
         row_size = int(item.dtype.itemsize * np.prod(item.shape[1:]))
 
         # chunk and store the data by (uncompressed) size
-        rows_per_chunk = int(_CHUNK_SIZE / row_size)
+        # increasing the rows per chunk by 1 because the value maybe 0
+        # Doesn't make much difference in the general case
+        # Will fail if row_size is greater than MAX_DOC_SIZE
+        rows_per_chunk = int(_CHUNK_SIZE / row_size) + 1
 
         symbol_all_previous_shas, version_shas = set(), set()
         if previous_version:

--- a/tests/integration/store/test_ndarray_store.py
+++ b/tests/integration/store/test_ndarray_store.py
@@ -95,6 +95,15 @@ def test_save_read_big_2darray(library, fw_pointers_cfg):
         assert np.all(ndarr == saved_arr)
 
 
+@pytest.mark.parametrize('fw_pointers_cfg', [FwPointersCfg.DISABLED, FwPointersCfg.HYBRID, FwPointersCfg.ENABLED])
+def test_save_read_massive_2darray(library, fw_pointers_cfg):
+    with FwPointersCtx(fw_pointers_cfg):
+        ndarr = np.random.rand(1, 320000)
+        library.write('MYARR', ndarr)
+        saved_arr = library.read('MYARR').data
+        assert np.all(ndarr == saved_arr)
+
+
 def test_get_info_bson_object(library):
     ndarr = np.ones(1000)
     library.write('MYARR', ndarr)


### PR DESCRIPTION
For large ndarrays, rows_size comes out to be greater than CHUNKS_SIZE, thus the value becomes 0. To handle division by zero, add 1 to rows_per_chunk which will not make a difference in the general case