### PR TITLE
VersionStore use named index

### DIFF
--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -70,6 +70,7 @@ class VersionStore(object):
         last_seq = self._version_nums.find_one({'symbol': symbol})
         return last_seq['version'] if last_seq else 0
 
+    # new index named because of 127 char restriction on fully qualified index names
     @mongo_retry
     def _ensure_index(self):
         collection = self._collection
@@ -79,7 +80,9 @@ class VersionStore(object):
                                          background=True)
         collection.versions.create_index([('symbol', pymongo.ASCENDING), ('version', pymongo.DESCENDING)], unique=True,
                                          background=True)
-        collection.versions.create_index([('symbol', pymongo.ASCENDING), ('version', pymongo.DESCENDING), ('metadata.deleted', pymongo.ASCENDING)],
+        collection.versions.create_index([('symbol', pymongo.ASCENDING), ('version', pymongo.DESCENDING),
+                                          ('metadata.deleted', pymongo.ASCENDING)],
+                                         name='versionstore_idx',
                                          background=True)
         collection.version_nums.create_index('symbol', unique=True, background=True)
         for th in _TYPE_HANDLERS:

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
                       "mockextras",
                       "pandas<=1.0.3",
                       "numpy<=1.18.4",
-                      "pymongo>=3.6.0, <= 3.11.0"
+                      "pymongo>=3.6.0, <= 3.11.0",
                       #"pytest-server-fixtures", # must be manual
                       "pytest-cov",
                       "pytest",

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -187,7 +187,7 @@ def test_ensure_index():
     assert vs._collection.versions.create_index.call_args_list == [
         call([('symbol', 1), ('_id', -1)], background=True),
         call([('symbol', 1), ('version', -1)], unique=True, background=True),
-        call([('symbol', 1), ('version', -1), ('metadata.deleted', 1)], background=True),
+        call([('symbol', 1), ('version', -1), ('metadata.deleted', 1)], background=True, name='versionstore_idx'),
     ]
     assert vs._collection.version_nums.create_index.call_args_list == [call('symbol', unique=True, background=True)]
     th._ensure_index.assert_called_once_with(vs._collection)


### PR DESCRIPTION
arctic 1.80.1 introduced a new index, when creating versionstores with  long db.collection names, we run up against the limit of 127 char fully qualified index names.  Workaround is to makesure the new index name is shorter than the existing auto-generated index name, which for a version store is : 'symbol_1_version_-1' len=19.