### PR TITLE
Updated links to ArcticDB website and docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,9 @@ mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
 
+myst enable extensions:
+- colon_fence
+- deflist
+- dollarmath
+myst_heading_anchors: 2
+myst_highlight_code_blocks: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,3 +13,4 @@ python:
 mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
 
-myst enable extensions:
+myst_enable_extensions:
 - colon_fence
 - deflist
 - dollarmath

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,3 @@ python:
 mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
-
-myst_enable_extensions:
-- colon_fence
-- deflist
-- dollarmath
-myst_heading_anchors: 2
-myst_highlight_code_blocks: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,13 @@
-```{tip}
-   [ArcticDB](https://arcticdb.io/#arctic1), Man Group's high-performance Python-native
-   DataFrame database is available on [GitHub](https://github.com/man-group/arcticdb).
+!!! important "Important"
+    ## ArcticDB
 
-   ArcticDB is the next generation of Arctic and is designed to be a drop-in replacement for it.
+    [ArcticDB](https://arcticdb.io/#arctic1) is a ground-up rewrite of Arctic.<br>
+    The old Arctic, described below, is in maintenance mode.<br>
+    ArcticDB uses a very similar api to Arctic and is much faster.
+    
+    Take a look:<br>
+    [Website](https://arcticdb.io/#arctic1), [Docs](https://docs.arcticdb.io/latest/#arctic1), [GitHub](https://github.com/man-group/arcticdb)
 
-   The docs below **do not describe ArcticDB**, but instead the older (first) version of the Arctic platform.
-   The docs for ArcticDB are available [here](https://docs.arcticdb.io/latest/#arctic1).
-
-   If you would like information on ArcticDB please see the [website](https://arcticdb.io/#arctic1).
-
-   The rest of these docs describe the first-generation Arctic platform.
-```
 # Arctic Introduction
 
 ## Arctic

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,15 +2,15 @@
 
 ## ArcticDB
 
-[ArcticDB](https://www.man.com/man-group-brings-powerful-dataframe-database-product-arcticdb-to-market-with-bloomberg), Man Group's high-performance Python-native
+[ArcticDB](https://arcticdb.io/), Man Group's high-performance Python-native
 DataFrame database is available on [GitHub](https://github.com/man-group/arcticdb).
 
 ArcticDB is the next generation of Arctic and is designed to be a drop-in replacement for it.
 
 These docs **do not describe ArcticDB**, but instead the older (first) version of the Arctic platform.
-The docs for ArcticDB are available [here](docs.arcticdb.io).
+The docs for ArcticDB are available [here](https://docs.arcticdb.io/latest/).
 
-If you would like information on ArcticDB please see the [website](arcticdb.io).
+If you would like information on ArcticDB please see the [website](https://arcticdb.io/).
 
 The rest of these docs describe the first-generation Arctic platform.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,17 @@
+.. tip::
+   [ArcticDB](https://arcticdb.io/#arctic1), Man Group's high-performance Python-native
+   DataFrame database is available on [GitHub](https://github.com/man-group/arcticdb).
+
+   ArcticDB is the next generation of Arctic and is designed to be a drop-in replacement for it.
+
+   The docs below **do not describe ArcticDB**, but instead the older (first) version of the Arctic platform.
+   The docs for ArcticDB are available [here](https://docs.arcticdb.io/latest/#arctic1).
+
+   If you would like information on ArcticDB please see the [website](https://arcticdb.io/#arctic1).
+
+   The rest of these docs describe the first-generation Arctic platform.
+
 # Arctic Introduction
-
-## ArcticDB
-
-[ArcticDB](https://arcticdb.io/#arctic1), Man Group's high-performance Python-native
-DataFrame database is available on [GitHub](https://github.com/man-group/arcticdb).
-
-ArcticDB is the next generation of Arctic and is designed to be a drop-in replacement for it.
-
-The docs below **do not describe ArcticDB**, but instead the older (first) version of the Arctic platform.
-The docs for ArcticDB are available [here](https://docs.arcticdb.io/latest/#arctic1).
-
-If you would like information on ArcticDB please see the [website](https://arcticdb.io/#arctic1).
-
-The rest of these docs describe the first-generation Arctic platform.
 
 ## Arctic
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,15 +2,15 @@
 
 ## ArcticDB
 
-[ArcticDB](https://arcticdb.io/), Man Group's high-performance Python-native
+[ArcticDB](https://arcticdb.io/#arctic1), Man Group's high-performance Python-native
 DataFrame database is available on [GitHub](https://github.com/man-group/arcticdb).
 
 ArcticDB is the next generation of Arctic and is designed to be a drop-in replacement for it.
 
-These docs **do not describe ArcticDB**, but instead the older (first) version of the Arctic platform.
-The docs for ArcticDB are available [here](https://docs.arcticdb.io/latest/).
+The docs below **do not describe ArcticDB**, but instead the older (first) version of the Arctic platform.
+The docs for ArcticDB are available [here](https://docs.arcticdb.io/latest/#arctic1).
 
-If you would like information on ArcticDB please see the [website](https://arcticdb.io/).
+If you would like information on ArcticDB please see the [website](https://arcticdb.io/#arctic1).
 
 The rest of these docs describe the first-generation Arctic platform.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-.. tip::
+```{tip}
    [ArcticDB](https://arcticdb.io/#arctic1), Man Group's high-performance Python-native
    DataFrame database is available on [GitHub](https://github.com/man-group/arcticdb).
 
@@ -10,7 +10,7 @@
    If you would like information on ArcticDB please see the [website](https://arcticdb.io/#arctic1).
 
    The rest of these docs describe the first-generation Arctic platform.
-
+```
 # Arctic Introduction
 
 ## Arctic

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-jinja2==3.0.0
-Markdown<3.2
-mkdocs>=1.2.3
+jinja2
+Markdown
+mkdocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,9 @@ repo_name: 'arctic'
 repo_url: 'https://github.com/man-group/arctic'
 edit_uri: edit/master/docs/
 
+markdown_extensions:
+  - admonition
+
 theme:
   name: 'readthedocs'
 


### PR DESCRIPTION
- Some of the links were not working from GitHub markdown docs, some needed to be updated.
- Removed requirements.txt module versions as these were causing docs build to fail. After changing these the docs build was successful locally.