### PR TITLE
Speedup tickstore read date index conversion

### DIFF
--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -334,7 +334,7 @@ class TickStore(object):
             raise NoDataFoundException("No Data found for {} in range: {}".format(symbol, date_range))
         rtn = self._pad_and_fix_dtypes(rtn, column_dtypes)
 
-        index = pd.to_datetime(np.concatenate(rtn[INDEX]), utc=True, unit='ms')
+        index = pd.DatetimeIndex(np.concatenate(rtn[INDEX]).astype('datetime64[ms]'), tz='UTC')
         if columns is None:
             columns = [x for x in rtn.keys() if x not in (INDEX, 'SYMBOL')]
         if multiple_symbols and 'SYMBOL' not in columns:


### PR DESCRIPTION
Speedup of Tickstore read datetime index conversion by ~40x.

Overall runtime improvement is around 3-4x on average, but this can vary depending on the mongo latency. 

```
%timeit  pd.DatetimeIndex(np.concatenate(rtn[INDEX]).astype('datetime64[ms]'), tz='UTC')
1.76 s ± 59.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit pd.to_datetime(np.concatenate(rtn[INDEX]), utc=True, unit='ms')
1min 16s ± 1.74 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**In the current implementation, the datetime conversion takes ~60% of the total runtime:**

![image](https://github.com/man-group/arctic/assets/37855280/22ff505d-6bf4-4998-8be3-08f37465f72f)


**The new implementation drops it down to ~5%**

![image](https://github.com/man-group/arctic/assets/37855280/44cfa7e1-492f-400a-86b1-7de650d5a4dd)



**Output of both implementations is identical (tested on 22.5 million values).** 

![image](https://github.com/man-group/arctic/assets/37855280/8baef216-511d-493c-87fb-6118b13c7ef1)

